### PR TITLE
Correctly prune all socket buffers on re-initialization

### DIFF
--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -150,6 +150,9 @@ where
         }
 
         self.network.clear_events()?;
+        if let Some(ref sockets) = self.sockets {
+            sockets.try_borrow_mut()?.prune();
+        }
 
         self.configure()?;
 

--- a/ublox-cellular/src/network.rs
+++ b/ublox-cellular/src/network.rs
@@ -233,7 +233,7 @@ where
                 }
                 Urc::SocketClosed(ip_transport_layer::urc::SocketClosed { socket }) => {
                     defmt::info!(
-                        "[URC] Socket {:?} closed! Should be followed by one more!",
+                        "[URC] Socket {:?} closed! Should be followed by one from data layer!",
                         socket
                     );
                     return false;

--- a/ublox-cellular/src/services/data/socket/set.rs
+++ b/ublox-cellular/src/services/data/socket/set.rs
@@ -216,6 +216,3 @@ where
         })
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/ublox-cellular/src/state.rs
+++ b/ublox-cellular/src/state.rs
@@ -152,9 +152,12 @@ impl StateMachine {
             State::Registered if matches!(event, CellularEvent::PwrOff) => State::Off,
             State::Registered if matches!(event, CellularEvent::RfOff) => State::Rfoff,
             State::Registered if matches!(event, CellularEvent::Detached) => State::On,
-            State::Registered if matches!(event, CellularEvent::Attached) => State::Registered,
             State::Registered if matches!(event, CellularEvent::DataActive) => State::Connected,
-            State::Registered if matches!(event, CellularEvent::DataInactive) => State::Registered,
+            State::Registered
+                if matches!(event, CellularEvent::Attached | CellularEvent::DataInactive) =>
+            {
+                State::Registered
+            }
             State::Connected if matches!(event, CellularEvent::PwrOff) => State::Off,
             State::Connected if matches!(event, CellularEvent::RfOff) => State::Rfoff,
             State::Connected if matches!(event, CellularEvent::Detached) => State::On,


### PR DESCRIPTION
Make sure that re-initializing the cellular driver actually prunes the socket set to a complete reset state.