### PR TITLE
Ensure re-initialize prunes buffers as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.fifo
 target/
 *.o
-.vscode
 **/*secrets*
 
 Cargo.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    // override the default setting (`cargo check --all-targets`) which produces the following error
+    // "can't find crate for `test`" when the default compilation target is a no_std target
+    // with these changes RA will call `cargo check --bins` on save
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.checkOnSave.extraArgs": [
+        "-bins",
+        "--target",
+        "x86_64-unknown-linux-gnu"
+    ],
+    "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
+    "rust-analyzer.diagnostics.disabled": [
+        "unresolved-import"
+    ]
+}

--- a/examples/linux/src/main.rs
+++ b/examples/linux/src/main.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use ublox_cellular::gprs::APNInfo;
 use ublox_cellular::prelude::*;
-use ublox_cellular::sockets::{Ipv4Addr, Mode, SocketAddrV4, SocketSet};
+use ublox_cellular::sockets::{Ipv4Addr, Mode, SocketAddrV4, SocketSet, Socket};
 use ublox_cellular::{error::Error as GSMError, Config, GsmClient};
 
 use atat::AtatClient;
@@ -23,7 +23,7 @@ where
     C: AtatClient,
     RST: OutputPin,
     DTR: OutputPin,
-    N: ArrayLength<Option<ublox_cellular::sockets::SocketSetItem<L>>>,
+    N: ArrayLength<Option<Socket<L>>>,
     L: ArrayLength<u8>,
 {
     gsm.init(true)?;

--- a/examples/linux_mqtt/src/main.rs
+++ b/examples/linux_mqtt/src/main.rs
@@ -6,7 +6,7 @@ use std::thread;
 
 use ublox_cellular::gprs::APNInfo;
 use ublox_cellular::prelude::*;
-use ublox_cellular::{error::Error as GSMError, sockets::SocketSet, Config, GsmClient};
+use ublox_cellular::{error::Error as GSMError, sockets::{SocketSet, Socket}, Config, GsmClient};
 
 use atat::{self, AtatClient, ClientBuilder, ComQueue, Queues, ResQueue, UrcQueue};
 use embedded_hal::digital::v2::OutputPin;
@@ -26,7 +26,7 @@ where
     C: AtatClient,
     RST: OutputPin,
     DTR: OutputPin,
-    N: ArrayLength<Option<ublox_cellular::sockets::SocketSetItem<L>>>,
+    N: ArrayLength<Option<Socket<L>>>,
     L: ArrayLength<u8>,
 {
     gsm.init(true)?;

--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -26,7 +26,7 @@ use crate::{
     config::{Config, NoPin},
     error::Error,
     network::{AtTx, Network},
-    services::data::socket::{SocketSet, SocketSetItem},
+    services::data::socket::{Socket, SocketSet},
     state::Event,
     state::StateMachine,
     State,
@@ -44,7 +44,7 @@ where
     C: AtatClient,
     DLY: DelayMs<u32> + CountDown,
     N: 'static
-        + ArrayLength<Option<SocketSetItem<L>>>
+        + ArrayLength<Option<Socket<L>>>
         + ArrayLength<Bucket<u8, usize>>
         + ArrayLength<Option<Pos>>,
     L: 'static + ArrayLength<u8>,
@@ -66,9 +66,7 @@ where
     PWR: OutputPin,
     DTR: OutputPin,
     VINT: InputPin,
-    N: ArrayLength<Option<SocketSetItem<L>>>
-        + ArrayLength<Bucket<u8, usize>>
-        + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Option<Socket<L>>> + ArrayLength<Bucket<u8, usize>> + ArrayLength<Option<Pos>>,
     L: ArrayLength<u8>,
 {
     pub fn new(client: C, delay: DLY, config: Config<RST, DTR, PWR, VINT>) -> Self {

--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -149,15 +149,20 @@ where
             self.is_alive(10)?;
         }
 
-        self.network.clear_events()?;
-        if let Some(ref sockets) = self.sockets {
-            sockets.try_borrow_mut()?.prune();
-        }
+        self.clear_buffers()?;
 
         self.configure()?;
 
         self.network.push_event(Event::PwrOn)?;
 
+        Ok(())
+    }
+
+    pub(crate) fn clear_buffers(&mut self) -> Result<(), Error> {
+        self.network.clear_events()?;
+        if let Some(ref sockets) = self.sockets {
+            sockets.try_borrow_mut()?.prune();
+        }
         Ok(())
     }
 
@@ -315,23 +320,14 @@ where
 
     #[inline]
     pub(crate) fn restart(&self, sim_reset: bool) -> Result<(), Error> {
-        if sim_reset {
-            self.network.send_internal(
-                &SetModuleFunctionality {
-                    fun: Functionality::SilentResetWithSimReset,
-                    rst: None,
-                },
-                false,
-            )?;
+        let fun = if sim_reset {
+            Functionality::SilentResetWithSimReset
         } else {
-            self.network.send_internal(
-                &SetModuleFunctionality {
-                    fun: Functionality::SilentReset,
-                    rst: None,
-                },
-                false,
-            )?;
-        }
+            Functionality::SilentReset
+        };
+
+        self.network
+            .send_internal(&SetModuleFunctionality { fun, rst: None }, false)?;
 
         self.network.push_event(Event::PwrOff)?;
         Ok(())
@@ -402,12 +398,13 @@ where
         }
 
         let state = self.fsm.get_state();
-
-        if let Err(_) = match state {
+        let res = match state {
             State::Unknown => self.restart(true),
             State::Off => self.initialize(true),
             _ => Ok(()),
-        } {
+        };
+
+        if res.is_err() {
             match self.fsm.retry_or_fail(&mut self.delay) {
                 nb::Error::WouldBlock => return Err(nb::Error::WouldBlock),
                 nb::Error::Other(_) => {
@@ -419,12 +416,10 @@ where
             }
         }
 
-        if matches!(state, State::On | State::Registered) {
-            Ok(false)
-        } else if matches!(state, State::Connected) {
-            Ok(true)
-        } else {
-            Err(nb::Error::WouldBlock)
+        match state {
+            State::On | State::Registered => Ok(false),
+            State::Connected => Ok(true),
+            _ => Err(nb::Error::WouldBlock),
         }
     }
 
@@ -436,5 +431,102 @@ where
         }
 
         Ok(self.network.send_internal(cmd, true)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::Config,
+        services::data::ContextState,
+        sockets::{SocketHandle, TcpSocket, UdpSocket},
+        APNInfo,
+    };
+    use crate::{
+        test_helpers::{MockAtClient, MockTimer},
+        ContextId,
+    };
+    use atat::typenum::Unsigned;
+    use heapless::consts;
+
+    type SocketSize = consts::U128;
+    type SocketSetLen = consts::U2;
+
+    static mut SOCKET_SET: Option<SocketSet<SocketSetLen, SocketSize>> = None;
+
+    #[test]
+    fn prune_on_initialize() {
+        let client = MockAtClient::new();
+        let timer = MockTimer::new();
+        let config = Config::default();
+
+        let socket_set: &'static mut _ = unsafe {
+            SOCKET_SET = Some(SocketSet::new());
+            SOCKET_SET.as_mut().unwrap_or_else(|| {
+                panic!("Failed to get the static com_queue");
+            })
+        };
+
+        let mut device =
+            Device::<_, _, SocketSetLen, SocketSize, _, _, _, _>::new(client, timer, config);
+        device.set_socket_storage(socket_set);
+
+        device.fsm.set_state(State::Connected);
+        assert_eq!(device.fsm.get_state(), State::Connected);
+        assert_eq!(device.spin(), Ok(true));
+
+        device.network.context_state.set(ContextState::Active);
+
+        let data_service = device
+            .data_service(ContextId(0), &APNInfo::default())
+            .unwrap();
+
+        let mut sockets = data_service.sockets.borrow_mut();
+
+        sockets
+            .add(TcpSocket::new(0))
+            .expect("Failed to add new tcp socket!");
+        assert_eq!(sockets.len(), 1);
+
+        let mut tcp = sockets
+            .get::<TcpSocket<_>>(SocketHandle(0))
+            .expect("Failed to get socket");
+
+        assert_eq!(tcp.rx_window(), SocketSize::to_usize());
+        let socket_data = b"This is socket data!!";
+        tcp.rx_enqueue_slice(socket_data);
+        assert_eq!(tcp.recv_queue(), socket_data.len());
+        assert_eq!(tcp.rx_window(), SocketSize::to_usize() - socket_data.len());
+
+        sockets
+            .add(UdpSocket::new(1))
+            .expect("Failed to add new udp socket!");
+        assert_eq!(sockets.len(), 2);
+
+        assert!(sockets.add(UdpSocket::new(0)).is_err());
+
+        drop(sockets);
+        drop(data_service);
+
+        device.clear_buffers().expect("Failed to clear buffers");
+
+        let data_service = device
+            .data_service(ContextId(0), &APNInfo::default())
+            .unwrap();
+
+        let mut sockets = data_service.sockets.borrow_mut();
+        assert_eq!(sockets.len(), 0);
+
+        sockets
+            .add(TcpSocket::new(0))
+            .expect("Failed to add new tcp socket!");
+        assert_eq!(sockets.len(), 1);
+
+        let tcp = sockets
+            .get::<TcpSocket<_>>(SocketHandle(0))
+            .expect("Failed to get socket");
+
+        assert_eq!(tcp.recv_queue(), 0);
     }
 }

--- a/ublox-cellular/src/command/network_service/impl_.rs
+++ b/ublox-cellular/src/command/network_service/impl_.rs
@@ -3,11 +3,10 @@ use crate::network::Error;
 
 impl NetworkRegistrationStat {
     pub fn is_access_alive(&self) -> bool {
-        match self {
-            NetworkRegistrationStat::Registered => true,
-            NetworkRegistrationStat::RegisteredRoaming => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            NetworkRegistrationStat::Registered | NetworkRegistrationStat::RegisteredRoaming
+        )
     }
 
     pub fn registration_ok(self) -> Result<Self, Error> {

--- a/ublox-cellular/src/config.rs
+++ b/ublox-cellular/src/config.rs
@@ -41,7 +41,7 @@ pub struct Config<RST, DTR, PWR, VINT> {
     pub(crate) pin: String<consts::U4>,
 }
 
-impl<RST, DTR, PWR, VINT> Default for Config<RST, DTR, PWR, VINT> {
+impl Default for Config<NoPin, NoPin, NoPin, NoPin> {
     fn default() -> Self {
         Config {
             rst_pin: None,

--- a/ublox-cellular/src/error.rs
+++ b/ublox-cellular/src/error.rs
@@ -2,7 +2,7 @@ use crate::network::Error as NetworkError;
 use crate::services::data::Error as DataServiceError;
 use core::cell::{BorrowError, BorrowMutError};
 
-#[derive(Debug, defmt::Format)]
+#[derive(Debug, PartialEq, defmt::Format)]
 pub enum GenericError {
     BorrowError,
     BorrowMutError,
@@ -20,7 +20,7 @@ impl From<BorrowError> for GenericError {
     }
 }
 
-#[derive(Debug, defmt::Format)]
+#[derive(Debug, PartialEq, defmt::Format)]
 #[non_exhaustive]
 pub enum Error {
     // General device errors

--- a/ublox-cellular/src/lib.rs
+++ b/ublox-cellular/src/lib.rs
@@ -8,6 +8,9 @@ mod network;
 mod services;
 mod state;
 
+#[cfg(test)]
+mod test_helpers;
+
 pub use client::Device as GsmClient;
 pub use config::Config;
 pub use network::{ContextId, ProfileId};

--- a/ublox-cellular/src/network.rs
+++ b/ublox-cellular/src/network.rs
@@ -22,7 +22,7 @@ use core::{
 use hash32_derive::Hash32;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, defmt::Format)]
+#[derive(Debug, PartialEq, defmt::Format)]
 pub enum Error {
     Generic(GenericError),
     AT(atat::Error),

--- a/ublox-cellular/src/services/data/dns.rs
+++ b/ublox-cellular/src/services/data/dns.rs
@@ -4,15 +4,13 @@ use embedded_nal::{AddrType, Dns};
 use heapless::{consts, ArrayLength, Bucket, Pos, String};
 use no_std_net::IpAddr;
 
-use super::{socket::SocketSetItem, DataService, Error};
+use super::{socket::Socket, DataService, Error};
 use crate::command::dns::{self, types::ResolutionType};
 
 impl<'a, C, N, L> Dns for DataService<'a, C, N, L>
 where
     C: AtatClient,
-    N: ArrayLength<Option<SocketSetItem<L>>>
-        + ArrayLength<Bucket<u8, usize>>
-        + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Option<Socket<L>>> + ArrayLength<Bucket<u8, usize>> + ArrayLength<Option<Pos>>,
     L: ArrayLength<u8>,
 {
     type Error = Error;

--- a/ublox-cellular/src/services/data/error.rs
+++ b/ublox-cellular/src/services/data/error.rs
@@ -3,7 +3,7 @@ use crate::error::GenericError;
 use crate::network::Error as NetworkError;
 use core::cell::{BorrowError, BorrowMutError};
 
-#[derive(Debug, defmt::Format)]
+#[derive(Debug, PartialEq, defmt::Format)]
 pub enum Error {
     InvalidApn,
     SocketClosed,

--- a/ublox-cellular/src/services/data/mod.rs
+++ b/ublox-cellular/src/services/data/mod.rs
@@ -50,7 +50,7 @@ use psn::{
     types::{AuthenticationType, PacketSwitchedAction},
     SetAuthParameters,
 };
-use socket::{Error as SocketError, Socket, SocketRef, SocketSet, SocketSetItem, SocketType};
+use socket::{Error as SocketError, Socket, SocketRef, SocketSet, SocketType};
 
 // NOTE: If these are changed, remember to change the corresponding `Bytes` len
 // in commands for now.
@@ -66,9 +66,7 @@ where
     PWR: OutputPin,
     DTR: OutputPin,
     VINT: InputPin,
-    N: ArrayLength<Option<SocketSetItem<L>>>
-        + ArrayLength<Bucket<u8, usize>>
-        + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Option<Socket<L>>> + ArrayLength<Bucket<u8, usize>> + ArrayLength<Option<Pos>>,
     L: ArrayLength<u8>,
 {
     pub fn data_service<'a>(
@@ -104,7 +102,7 @@ pub struct DataService<'a, C, N, L>
 where
     C: atat::AtatClient,
     N: 'static
-        + ArrayLength<Option<SocketSetItem<L>>>
+        + ArrayLength<Option<Socket<L>>>
         + ArrayLength<Bucket<u8, usize>>
         + ArrayLength<Option<Pos>>,
     L: 'static + ArrayLength<u8>,
@@ -117,7 +115,7 @@ impl<'a, C, N, L> DataService<'a, C, N, L>
 where
     C: atat::AtatClient,
     N: 'static
-        + ArrayLength<Option<SocketSetItem<L>>>
+        + ArrayLength<Option<Socket<L>>>
         + ArrayLength<Bucket<u8, usize>>
         + ArrayLength<Option<Pos>>,
     L: 'static + ArrayLength<u8>,

--- a/ublox-cellular/src/services/data/socket/mod.rs
+++ b/ublox-cellular/src/services/data/socket/mod.rs
@@ -14,10 +14,9 @@ pub use tcp::{State as TcpState, TcpSocket};
 #[cfg(feature = "socket-udp")]
 pub use udp::UdpSocket;
 
-pub use self::set::{Handle as SocketHandle, Item as SocketSetItem, Set as SocketSet};
+pub use self::set::{Handle as SocketHandle, Set as SocketSet};
 
 pub use self::ref_::Ref as SocketRef;
-pub(crate) use self::ref_::Session as SocketSession;
 
 /// The error type for the networking stack.
 #[non_exhaustive]
@@ -136,23 +135,8 @@ impl<L: ArrayLength<u8>> Socket<L> {
     }
 }
 
-impl<L: ArrayLength<u8>> SocketSession for Socket<L> {
-    fn finish(&mut self) {
-        match self {
-            // #[cfg(feature = "socket-raw")]
-            // Socket::Raw(ref $( $mut_ )* $socket) => $code,
-            // #[cfg(all(feature = "socket-icmp", any(feature = "proto-ipv4", feature = "proto-ipv6")))]
-            // Socket::Icmp(ref $( $mut_ )* $socket) => $code,
-            #[cfg(feature = "socket-udp")]
-            Socket::Udp(ref mut socket) => socket.finish(),
-            #[cfg(feature = "socket-tcp")]
-            Socket::Tcp(ref mut socket) => socket.finish(),
-        }
-    }
-}
-
 /// A conversion trait for network sockets.
-pub trait AnySocket<L: ArrayLength<u8>>: SocketSession + Sized {
+pub trait AnySocket<L: ArrayLength<u8>>: Sized {
     fn downcast(socket_ref: SocketRef<'_, Socket<L>>) -> Result<SocketRef<'_, Self>>;
 }
 

--- a/ublox-cellular/src/services/data/socket/mod.rs
+++ b/ublox-cellular/src/services/data/socket/mod.rs
@@ -34,6 +34,7 @@ pub enum Error {
 
     SocketSetFull,
     InvalidSocket,
+    DuplicateSocket,
 }
 
 type Result<T> = core::result::Result<T, Error>;

--- a/ublox-cellular/src/services/data/socket/ring_buffer.rs
+++ b/ublox-cellular/src/services/data/socket/ring_buffer.rs
@@ -143,7 +143,7 @@ impl<T: Default + Clone, N: ArrayLength<T>> RingBuffer<T, N> {
     /// or return `Err(Error::Exhausted)` if the buffer is full.
     ///
     /// This function is a shortcut for `ring_buf.enqueue_one_with(Ok)`.
-    pub fn enqueue_one<'b>(&'b mut self) -> Result<&'b mut T> {
+    pub fn enqueue_one(&mut self) -> Result<&mut T> {
         self.enqueue_one_with(Ok)
     }
 

--- a/ublox-cellular/src/services/data/ssl.rs
+++ b/ublox-cellular/src/services/data/ssl.rs
@@ -1,5 +1,5 @@
 use super::{
-    socket::{SocketHandle, SocketSetItem},
+    socket::{Socket, SocketHandle},
     DataService, Error,
 };
 use crate::{
@@ -39,9 +39,7 @@ pub trait SSL {
 impl<'a, C, N, L> SSL for DataService<'a, C, N, L>
 where
     C: atat::AtatClient,
-    N: ArrayLength<Option<SocketSetItem<L>>>
-        + ArrayLength<Bucket<u8, usize>>
-        + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Option<Socket<L>>> + ArrayLength<Bucket<u8, usize>> + ArrayLength<Option<Pos>>,
     L: ArrayLength<u8>,
 {
     fn import_certificate(

--- a/ublox-cellular/src/services/data/tcp_stack.rs
+++ b/ublox-cellular/src/services/data/tcp_stack.rs
@@ -1,7 +1,7 @@
 use super::ssl::{SecurityProfileId, SSL};
 use super::DataService;
 use super::{
-    socket::{Error as SocketError, SocketHandle, SocketSetItem, TcpSocket, TcpState},
+    socket::{Error as SocketError, Socket, SocketHandle, TcpSocket, TcpState},
     EgressChunkSize, Error,
 };
 use crate::command::ip_transport_layer::{
@@ -16,7 +16,7 @@ impl<'a, C, N, L> TcpClient for DataService<'a, C, N, L>
 where
     C: atat::AtatClient,
     N: 'static
-        + ArrayLength<Option<SocketSetItem<L>>>
+        + ArrayLength<Option<Socket<L>>>
         + ArrayLength<Bucket<u8, usize>>
         + ArrayLength<Option<Pos>>,
     L: 'static + ArrayLength<u8>,

--- a/ublox-cellular/src/services/data/udp_stack.rs
+++ b/ublox-cellular/src/services/data/udp_stack.rs
@@ -1,6 +1,6 @@
 use super::DataService;
 use super::{
-    socket::{SocketHandle, SocketSetItem, UdpSocket},
+    socket::{Socket, SocketHandle, UdpSocket},
     EgressChunkSize, Error,
 };
 use crate::command::ip_transport_layer::{
@@ -15,7 +15,7 @@ impl<'a, C, N, L> UdpClient for DataService<'a, C, N, L>
 where
     C: atat::AtatClient,
     N: 'static
-        + ArrayLength<Option<SocketSetItem<L>>>
+        + ArrayLength<Option<Socket<L>>>
         + ArrayLength<Bucket<u8, usize>>
         + ArrayLength<Option<Pos>>,
     L: 'static + ArrayLength<u8>,

--- a/ublox-cellular/src/services/location/mod.rs
+++ b/ublox-cellular/src/services/location/mod.rs
@@ -1,4 +1,4 @@
-use crate::services::data::socket::SocketSetItem;
+use crate::services::data::socket::Socket;
 use crate::{client::Device, error::Error as DeviceError};
 use atat::AtatClient;
 use embedded_hal::{
@@ -17,9 +17,7 @@ where
     PWR: OutputPin,
     DTR: OutputPin,
     VINT: InputPin,
-    N: ArrayLength<Option<SocketSetItem<L>>>
-        + ArrayLength<Bucket<u8, usize>>
-        + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Option<Socket<L>>> + ArrayLength<Bucket<u8, usize>> + ArrayLength<Option<Pos>>,
     L: ArrayLength<u8>,
 {
     pub fn location_service(&mut self) -> nb::Result<LocationService, DeviceError> {

--- a/ublox-cellular/src/state.rs
+++ b/ublox-cellular/src/state.rs
@@ -454,6 +454,12 @@ impl NetworkStatus {
     }
 }
 
+impl Default for NetworkStatus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<NetworkRegistration> for RegistrationParams {
     fn from(v: NetworkRegistration) -> Self {
         Self {
@@ -660,32 +666,7 @@ impl From<usize> for RadioAccessNetwork {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    struct MockTimer {
-        time: Option<u32>,
-    }
-
-    impl MockTimer {
-        pub fn new() -> Self {
-            MockTimer { time: None }
-        }
-    }
-
-    impl CountDown for MockTimer {
-        type Error = core::convert::Infallible;
-        type Time = u32;
-        fn try_start<T>(&mut self, count: T) -> Result<(), Self::Error>
-        where
-            T: Into<Self::Time>,
-        {
-            self.time = Some(count.into());
-            Ok(())
-        }
-        fn try_wait(&mut self) -> nb::Result<(), Self::Error> {
-            self.time = None;
-            Ok(())
-        }
-    }
+    use crate::test_helpers::MockTimer;
 
     #[test]
     fn retry_or_fail() {

--- a/ublox-cellular/src/test_helpers.rs
+++ b/ublox-cellular/src/test_helpers.rs
@@ -1,0 +1,65 @@
+use atat::AtatClient;
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::timer::CountDown;
+
+pub struct MockTimer {
+    pub time: Option<u32>,
+}
+
+impl MockTimer {
+    pub fn new() -> Self {
+        MockTimer { time: None }
+    }
+}
+
+impl CountDown for MockTimer {
+    type Error = core::convert::Infallible;
+    type Time = u32;
+    fn try_start<T>(&mut self, count: T) -> Result<(), Self::Error>
+    where
+        T: Into<Self::Time>,
+    {
+        self.time = Some(count.into());
+        Ok(())
+    }
+    fn try_wait(&mut self) -> nb::Result<(), Self::Error> {
+        self.time = None;
+        Ok(())
+    }
+}
+
+impl DelayMs<u32> for MockTimer {
+    type Error = core::convert::Infallible;
+
+    fn try_delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+        self.try_start(ms)?;
+        nb::block!(self.try_wait())
+    }
+}
+
+pub struct MockAtClient {}
+
+impl MockAtClient {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl AtatClient for MockAtClient {
+    fn send<A: atat::AtatCmd>(&mut self, _cmd: &A) -> nb::Result<A::Response, atat::Error> {
+        todo!()
+    }
+
+    fn peek_urc_with<URC: atat::AtatUrc, F: FnOnce(URC::Response) -> bool>(&mut self, _f: F) {}
+
+    fn check_response<A: atat::AtatCmd>(
+        &mut self,
+        _cmd: &A,
+    ) -> nb::Result<A::Response, atat::Error> {
+        todo!()
+    }
+
+    fn get_mode(&self) -> atat::Mode {
+        todo!()
+    }
+}


### PR DESCRIPTION
- Add tests covering re-initializing the device from a running state
- Clean up socketset functions. 
- Add socket uniqueness check, fixes #33
- Add unit tests for `SocketSet`