### PR TITLE
Allow sockets closed by remote to be read until a read_timeout

### DIFF
--- a/ublox-cellular/src/command/general/mod.rs
+++ b/ublox-cellular/src/command/general/mod.rs
@@ -13,6 +13,20 @@ use types::*;
 #[at_cmd("+CGMI", ManufacturerId)]
 pub struct GetManufacturerId;
 
+/// 4.3 Model identification +CGMM
+///
+/// Text string identifying the model identification.
+#[derive(Clone, AtatCmd)]
+#[at_cmd("+CGMI", ModelId)]
+pub struct GetModelId;
+
+/// 4.5 Firmware version identification +CGMR
+///
+/// Returns the firmware version of the module.
+#[derive(Clone, AtatCmd)]
+#[at_cmd("+CGMR", FirmwareVersion)]
+pub struct GetFirmwareVersion;
+
 /// 4.7 IMEI identification +CGSN
 ///
 /// Returns the product serial number, the International Mobile Equipment Identity (IMEI) of the MT.

--- a/ublox-cellular/src/command/general/responses.rs
+++ b/ublox-cellular/src/command/general/responses.rs
@@ -1,13 +1,30 @@
 //! Responses for General Commands
 use atat::atat_derive::AtatResp;
-use heapless::{consts, String};
+use heapless::consts;
+use serde_at::CharVec;
 
 /// 4.1 Manufacturer identification
 /// Text string identifying the manufacturer.
 #[derive(Clone, Debug, AtatResp)]
 pub struct ManufacturerId {
     #[at_arg(position = 0)]
-    pub id: String<consts::U64>,
+    pub manufacturer: CharVec<consts::U10>,
+}
+
+/// 4.3 Model identification
+/// Text string identifying the model identification.
+#[derive(Clone, Debug, AtatResp)]
+pub struct ModelId {
+    #[at_arg(position = 0)]
+    pub model: CharVec<consts::U16>,
+}
+
+/// 4.5 Firmware version identification
+/// Returns the firmware version of the module.
+#[derive(Clone, Debug, AtatResp)]
+pub struct FirmwareVersion {
+    #[at_arg(position = 0)]
+    pub version: CharVec<consts::U10>,
 }
 
 /// 4.7 IMEI identification +CGSN
@@ -26,7 +43,7 @@ pub struct IMEI {
 /// about the firmware version.
 #[derive(Clone, Debug, AtatResp)]
 pub struct IdentificationInformationResponse {
-    pub app_ver: String<consts::U32>,
+    pub app_ver: CharVec<consts::U32>,
 }
 
 /// 4.11 International mobile subscriber identification +CIM

--- a/ublox-cellular/src/services/data/socket/mod.rs
+++ b/ublox-cellular/src/services/data/socket/mod.rs
@@ -121,6 +121,26 @@ impl<L: ArrayLength<u8>, CLK: Clock> Socket<L, CLK> {
         }
     }
 
+    pub fn recycle(&self, ts: &Instant<CLK>) -> bool
+    where
+        Generic<CLK::T>: TryInto<Milliseconds>,
+    {
+        match self {
+            Socket::Tcp(s) => s.recycle(ts),
+            Socket::Udp(s) => s.recycle(ts),
+        }
+    }
+
+    pub fn closed_by_remote(&mut self, ts: Instant<CLK>)
+    where
+        Generic<CLK::T>: TryInto<Milliseconds>,
+    {
+        match self {
+            Socket::Tcp(s) => s.closed_by_remote(ts),
+            Socket::Udp(s) => s.closed_by_remote(ts),
+        }
+    }
+
     pub fn set_available_data(&mut self, available_data: usize) {
         match self {
             Socket::Tcp(s) => s.set_available_data(available_data),

--- a/ublox-cellular/src/services/data/socket/set.rs
+++ b/ublox-cellular/src/services/data/socket/set.rs
@@ -1,6 +1,11 @@
+use core::convert::TryInto;
+
 use super::{AnySocket, Error, Result, Socket, SocketRef, SocketType};
 
-use embedded_time::Clock;
+use embedded_time::{
+    duration::{Generic, Milliseconds},
+    Clock, Instant,
+};
 use heapless::{ArrayLength, Vec};
 use serde::{Deserialize, Serialize};
 
@@ -145,6 +150,17 @@ where
                 defmt::error!("Removing socket @ index {}", index);
                 slot.take();
             })
+    }
+
+    pub fn recycle(&mut self, ts: &Instant<CLK>) -> bool
+    where
+        Generic<CLK::T>: TryInto<Milliseconds>,
+    {
+        let h = self.iter().find(|(_, s)| s.recycle(ts)).map(|(h, _)| h);
+        if h.is_none() {
+            return false;
+        }
+        self.remove(h.unwrap()).is_ok()
     }
 
     /// Iterate every socket in this set.

--- a/ublox-cellular/src/services/data/socket/udp.rs
+++ b/ublox-cellular/src/services/data/socket/udp.rs
@@ -18,9 +18,11 @@ pub struct UdpSocket<L: ArrayLength<u8>, CLK: Clock> {
     pub(crate) meta: SocketMeta,
     pub(crate) endpoint: SocketAddr,
     check_interval: Seconds<u32>,
+    read_timeout: Option<Seconds<u32>>,
     available_data: usize,
     rx_buffer: SocketBuffer<L>,
     last_check_time: Option<Instant<CLK>>,
+    closed_time: Option<Instant<CLK>>,
 }
 
 impl<L: ArrayLength<u8>, CLK: Clock> UdpSocket<L, CLK> {
@@ -31,10 +33,12 @@ impl<L: ArrayLength<u8>, CLK: Clock> UdpSocket<L, CLK> {
                 handle: SocketHandle(socket_id),
             },
             check_interval: Seconds(15),
+            read_timeout: Some(Seconds(15)),
             endpoint: SocketAddrV4::new(Ipv4Addr::unspecified(), 0).into(),
             available_data: 0,
             rx_buffer: SocketBuffer::new(),
             last_check_time: None,
+            closed_time: None,
         }
     }
 
@@ -60,6 +64,28 @@ impl<L: ArrayLength<u8>, CLK: Clock> UdpSocket<L, CLK> {
             .and_then(|dur| dur.try_into().ok())
             .map(|dur: Milliseconds<u32>| dur >= self.check_interval)
             .unwrap_or(false)
+    }
+
+    pub fn recycle(&self, ts: &Instant<CLK>) -> bool
+    where
+        Generic<CLK::T>: TryInto<Milliseconds>,
+    {
+        if let Some(read_timeout) = self.read_timeout {
+            self.closed_time
+                .and_then(|ref closed_time| ts.checked_duration_since(closed_time))
+                .and_then(|dur| dur.try_into().ok())
+                .map(|dur: Milliseconds<u32>| dur >= read_timeout)
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
+    pub fn closed_by_remote(&mut self, ts: Instant<CLK>)
+    where
+        Generic<CLK::T>: TryInto<Milliseconds>,
+    {
+        self.closed_time.replace(ts);
     }
 
     /// Set available data.

--- a/ublox-cellular/src/services/data/udp_stack.rs
+++ b/ublox-cellular/src/services/data/udp_stack.rs
@@ -1,3 +1,5 @@
+use core::convert::TryInto;
+
 use super::DataService;
 use super::{
     socket::{Error as SocketError, Socket, SocketHandle, UdpSocket},
@@ -9,13 +11,17 @@ use crate::command::ip_transport_layer::{
 };
 use atat::typenum::Unsigned;
 use embedded_nal::{SocketAddr, UdpClient};
-use embedded_time::Clock;
+use embedded_time::{
+    duration::{Generic, Milliseconds},
+    Clock,
+};
 use heapless::{ArrayLength, Bucket, Pos};
 
 impl<'a, C, CLK, N, L> UdpClient for DataService<'a, C, CLK, N, L>
 where
     C: atat::AtatClient,
     CLK: Clock,
+    Generic<CLK::T>: TryInto<Milliseconds>,
     N: 'static
         + ArrayLength<Option<Socket<L, CLK>>>
         + ArrayLength<Bucket<u8, usize>>
@@ -34,7 +40,15 @@ where
         let mut sockets = self.sockets.try_borrow_mut()?;
 
         if sockets.len() >= sockets.capacity() {
-            return Err(Error::Socket(SocketError::SocketSetFull));
+            if let Ok(ts) = self.network.status.try_borrow_mut()?.timer.try_now() {
+                // Check if there are any sockets closed by remote, and close it
+                // if it has exceeded its timeout, in order to recycle it.
+                if sockets.recycle(&ts) {
+                    return Err(Error::Socket(SocketError::SocketSetFull));
+                }
+            } else {
+                return Err(Error::Socket(SocketError::SocketSetFull));
+            }
         }
 
         let socket_resp = self.network.send_internal(


### PR DESCRIPTION
Allow sockets closed by remote to be read until a read_timeout has been exceeded & a new socket is requested in a full socketset. 

Also fixes minor stuff around timezone updates.

Fixes #35

TCP sockets now follows the state diagram shown in ![tcp_flow](https://user-images.githubusercontent.com/1862272/107019803-66ae6480-67a2-11eb-80b4-d5354e7e408f.png)


**TODO:** 
- The read_timeout is currently fixed at 15 seconds. This should be configurable