### PR TITLE
Remove RefCells & Cells

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ members = [
     # "examples/linux_mqtt",
     # "examples/linux_jobs",
 ]
+
+
+[patch.crates-io]
+embedded-nal = { path = "../embedded-nal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,3 @@ members = [
     # "examples/linux_mqtt",
     # "examples/linux_jobs",
 ]
-
-
-[patch.crates-io]
-embedded-nal = { path = "../embedded-nal" }

--- a/ublox-cellular/Cargo.toml
+++ b/ublox-cellular/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 atat = { version = "0.11.0", features = ["derive", "defmt"] }
 defmt = { version = "^0.2" }
 embedded-hal = "1.0.0-alpha.4"
-embedded-nal = "0.5.0"
+embedded-nal = "0.6.0"
 embedded-time = "0.10.1"
 hash32 = "^0.2.1"
 hash32-derive = "^0.1.0"

--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -545,12 +545,13 @@ mod tests {
 
         let data_service = device.data_service(&APNInfo::default()).unwrap();
 
-        self.sockets
+        data_service
+            .sockets
             .add(TcpSocket::new(0))
             .expect("Failed to add new tcp socket!");
-        assert_eq!(sockets.len(), 1);
+        assert_eq!(data_service.sockets.len(), 1);
 
-        let mut tcp = self
+        let mut tcp = data_service
             .sockets
             .get::<TcpSocket<_, SOCKET_SIZE>>(SocketHandle(0))
             .expect("Failed to get socket");
@@ -561,12 +562,13 @@ mod tests {
         assert_eq!(tcp.recv_queue(), socket_data.len());
         assert_eq!(tcp.rx_window(), SOCKET_SIZE - socket_data.len());
 
-        self.sockets
+        data_service
+            .sockets
             .add(UdpSocket::new(1))
             .expect("Failed to add new udp socket!");
-        assert_eq!(self.sockets.len(), 2);
+        assert_eq!(data_service.sockets.len(), 2);
 
-        assert!(self.sockets.add(UdpSocket::new(0)).is_err());
+        assert!(data_service.sockets.add(UdpSocket::new(0)).is_err());
 
         drop(data_service);
 
@@ -574,14 +576,15 @@ mod tests {
 
         let data_service = device.data_service(&APNInfo::default()).unwrap();
 
-        assert_eq!(self.sockets.len(), 0);
+        assert_eq!(data_service.sockets.len(), 0);
 
-        self.sockets
+        data_service
+            .sockets
             .add(TcpSocket::new(0))
             .expect("Failed to add new tcp socket!");
-        assert_eq!(self.sockets.len(), 1);
+        assert_eq!(data_service.sockets.len(), 1);
 
-        let tcp = self
+        let tcp = data_service
             .sockets
             .get::<TcpSocket<_, SOCKET_SIZE>>(SocketHandle(0))
             .expect("Failed to get socket");

--- a/ublox-cellular/src/command/error.rs
+++ b/ublox-cellular/src/command/error.rs
@@ -40,9 +40,9 @@ impl FromStr for CmsError {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s.trim() {
+        match s.trim() {
             _ => return Err(()),
-        })
+        }
     }
 }
 

--- a/ublox-cellular/src/error.rs
+++ b/ublox-cellular/src/error.rs
@@ -2,27 +2,12 @@ use embedded_time::TimeError;
 
 use crate::network::Error as NetworkError;
 use crate::services::data::Error as DataServiceError;
-use core::cell::{BorrowError, BorrowMutError};
 
 #[derive(Debug, PartialEq)]
 pub enum GenericError {
-    BorrowError,
-    BorrowMutError,
     Timeout,
     Time(TimeError),
     Unsupported,
-}
-
-impl From<BorrowMutError> for GenericError {
-    fn from(_: BorrowMutError) -> Self {
-        GenericError::BorrowMutError
-    }
-}
-
-impl From<BorrowError> for GenericError {
-    fn from(_: BorrowError) -> Self {
-        GenericError::BorrowError
-    }
 }
 
 impl From<TimeError> for GenericError {
@@ -75,18 +60,6 @@ impl From<NetworkError> for Error {
 
 impl From<TimeError> for Error {
     fn from(e: TimeError) -> Self {
-        Error::Generic(e.into())
-    }
-}
-
-impl From<BorrowMutError> for Error {
-    fn from(e: BorrowMutError) -> Self {
-        Error::Generic(e.into())
-    }
-}
-
-impl From<BorrowError> for Error {
-    fn from(e: BorrowError) -> Self {
         Error::Generic(e.into())
     }
 }

--- a/ublox-cellular/src/network.rs
+++ b/ublox-cellular/src/network.rs
@@ -15,14 +15,11 @@ use crate::{
         Urc,
     },
     error::GenericError,
-    registration::{self, ConnectionState, RegistrationState},
+    registration::{self, ConnectionState, RegistrationParams, RegistrationState},
     services::data::ContextState,
 };
 use atat::{atat_derive::AtatLen, AtatClient};
-use core::{
-    cell::{BorrowError, BorrowMutError, Cell, RefCell},
-    convert::TryInto,
-};
+use core::convert::TryInto;
 use embedded_time::{duration::*, Clock, TimeError};
 use hash32_derive::Hash32;
 use serde::{Deserialize, Serialize};
@@ -46,18 +43,6 @@ impl From<TimeError> for Error {
     }
 }
 
-impl From<BorrowMutError> for Error {
-    fn from(e: BorrowMutError) -> Self {
-        Error::Generic(e.into())
-    }
-}
-
-impl From<BorrowError> for Error {
-    fn from(e: BorrowError) -> Self {
-        Error::Generic(e.into())
-    }
-}
-
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash32, Serialize, Deserialize, AtatLen, defmt::Format,
 )]
@@ -67,34 +52,36 @@ pub struct ProfileId(pub u8);
 pub struct ContextId(pub u8);
 
 pub struct AtTx<C> {
-    urc_attempts: Cell<u8>,
+    urc_attempts: u8,
     max_urc_attempts: u8,
-    consecutive_timeouts: Cell<u8>,
-    client: RefCell<C>,
+    consecutive_timeouts: u8,
+    client: C,
 }
 
 impl<C: AtatClient> AtTx<C> {
     pub fn new(client: C, max_urc_attempts: u8) -> Self {
         Self {
-            urc_attempts: Cell::new(0),
-            consecutive_timeouts: Cell::new(0),
+            urc_attempts: 0,
+            consecutive_timeouts: 0,
             max_urc_attempts,
-            client: RefCell::new(client),
+            client,
         }
     }
 
-    pub fn reset(&self) -> Result<(), Error> {
-        self.client.try_borrow_mut()?.reset();
+    pub fn reset(&mut self) -> Result<(), Error> {
+        self.client.reset();
         Ok(())
     }
 
-    pub fn send_ignore_timeout<A, const LEN: usize>(&self, req: &A) -> Result<A::Response, Error>
+    pub fn send_ignore_timeout<A, const LEN: usize>(
+        &mut self,
+        req: &A,
+    ) -> Result<A::Response, Error>
     where
         A: atat::AtatCmd<LEN>,
         A::Error: Into<UbloxError>,
     {
         self.client
-            .try_borrow_mut()?
             .send(req)
             .map_err(|e| match e {
                 nb::Error::Other(ate) => {
@@ -110,8 +97,7 @@ impl<C: AtatClient> AtTx<C> {
                             Error::AT(atat::Error::Error(u))
                         }
                         atat::Error::Timeout => {
-                            let new_value = self.consecutive_timeouts.get() + 1;
-                            self.consecutive_timeouts.set(new_value);
+                            self.consecutive_timeouts += 1;
                             Error::AT(atat::Error::Timeout)
                         }
                         atat::Error::Read => Error::AT(atat::Error::Read),
@@ -125,18 +111,17 @@ impl<C: AtatClient> AtTx<C> {
                 nb::Error::WouldBlock => Error::_Unknown,
             })
             .map(|res| {
-                self.consecutive_timeouts.set(0);
+                self.consecutive_timeouts = 0;
                 res
             })
     }
 
-    pub fn send<A, const LEN: usize>(&self, req: &A) -> Result<A::Response, Error>
+    pub fn send<A, const LEN: usize>(&mut self, req: &A) -> Result<A::Response, Error>
     where
         A: atat::AtatCmd<LEN>,
         A::Error: Into<UbloxError>,
     {
         self.client
-            .try_borrow_mut()?
             .send(req)
             .map_err(|e| match e {
                 nb::Error::Other(ate) => {
@@ -149,8 +134,7 @@ impl<C: AtatClient> AtTx<C> {
                             Error::AT(atat::Error::Error(u))
                         }
                         atat::Error::Timeout => {
-                            let new_value = self.consecutive_timeouts.get() + 1;
-                            self.consecutive_timeouts.set(new_value);
+                            self.consecutive_timeouts += 1;
                             Error::AT(atat::Error::Timeout)
                         }
                         atat::Error::Read => Error::AT(atat::Error::Read),
@@ -164,28 +148,28 @@ impl<C: AtatClient> AtTx<C> {
                 nb::Error::WouldBlock => Error::_Unknown,
             })
             .map(|res| {
-                self.consecutive_timeouts.set(0);
+                self.consecutive_timeouts = 0;
                 res
             })
     }
 
-    pub fn handle_urc<F: FnOnce(Urc) -> bool>(&self, f: F) -> Result<(), Error> {
-        self.client
-            .try_borrow_mut()?
-            .peek_urc_with::<Urc, _>(|urc| {
-                if !f(urc.clone()) {
-                    let a = self.urc_attempts.get();
-                    if a < self.max_urc_attempts {
-                        self.urc_attempts.set(a + 1);
-                        return false;
-                    } else {
-                        defmt::warn!("Dropping stale URC! {}", defmt::Debug2Format(&urc));
-                    }
-                }
-                self.urc_attempts.set(0);
-                true
-            });
+    pub fn handle_urc<F: FnOnce(Urc) -> bool>(&mut self, f: F) -> Result<(), Error> {
+        let mut a = self.urc_attempts;
+        let max = self.max_urc_attempts;
 
+        self.client.peek_urc_with::<Urc, _>(|urc| {
+            if !f(urc.clone()) {
+                if a < max {
+                    a += 1;
+                    return false;
+                } else {
+                    defmt::warn!("Dropping stale URC! {}", defmt::Debug2Format(&urc));
+                }
+            }
+            a = 0;
+            true
+        });
+        self.urc_attempts = a;
         Ok(())
     }
 }
@@ -194,8 +178,8 @@ pub struct Network<C, CLK>
 where
     CLK: Clock,
 {
-    pub(crate) status: RefCell<RegistrationState<CLK>>,
-    pub(crate) context_state: Cell<ContextState>,
+    pub(crate) status: RegistrationState<CLK>,
+    pub(crate) context_state: ContextState,
     pub(crate) at_tx: AtTx<C>,
 }
 
@@ -206,31 +190,29 @@ where
 {
     pub(crate) fn new(at_tx: AtTx<C>, timer: CLK) -> Self {
         Network {
-            status: RefCell::new(RegistrationState::new(timer)),
-            context_state: Cell::new(ContextState::Setup),
+            status: RegistrationState::new(timer),
+            context_state: ContextState::Setup,
             at_tx,
         }
     }
 
     pub fn is_connected(&self) -> Result<bool, Error> {
-        let ns = self.status.try_borrow()?;
-        Ok(matches!(ns.conn_state, ConnectionState::Connected))
+        Ok(matches!(self.status.conn_state, ConnectionState::Connected))
     }
 
-    pub fn reset_reg_time(&self) -> Result<(), Error> {
-        let mut ns = self.status.try_borrow_mut()?;
-        let now = ns.timer.try_now().map_err(TimeError::from)?;
+    pub fn reset_reg_time(&mut self) -> Result<(), Error> {
+        let now = self.status.timer.try_now().map_err(TimeError::from)?;
 
-        ns.reg_start_time.replace(now);
-        ns.reg_check_time = ns.reg_start_time;
+        self.status.reg_start_time.replace(now);
+        self.status.reg_check_time = self.status.reg_start_time;
         Ok(())
     }
 
-    pub fn process_events(&self) -> Result<(), Error>
+    pub fn process_events(&mut self) -> Result<(), Error>
     where
         Generic<CLK::T>: TryInto<Milliseconds>,
     {
-        if self.at_tx.consecutive_timeouts.get() > 10 {
+        if self.at_tx.consecutive_timeouts > 10 {
             defmt::warn!("Resetting the modem due to consecutive AT timeouts");
             return Err(Error::Generic(GenericError::Timeout));
         }
@@ -240,10 +222,9 @@ where
         self.intervene_registration()?;
         // self.check_running_imsi();
 
-        let mut ns = self.status.try_borrow_mut()?;
-
-        let now = ns.timer.try_now().map_err(TimeError::from)?;
-        let should_check = ns
+        let now = self.status.timer.try_now().map_err(TimeError::from)?;
+        let should_check = self
+            .status
             .reg_check_time
             .and_then(|ref reg_check_time| {
                 now.checked_duration_since(reg_check_time)
@@ -252,18 +233,17 @@ where
             })
             .unwrap_or(true);
 
-        if ns.conn_state != ConnectionState::Connecting || !should_check {
+        if self.status.conn_state != ConnectionState::Connecting || !should_check {
             return Ok(());
         }
 
-        ns.reg_check_time.replace(now);
-        drop(ns);
+        self.status.reg_check_time.replace(now);
 
         self.update_registration()?;
 
-        let ns = self.status.try_borrow()?;
-        let now = ns.timer.try_now().map_err(TimeError::from)?;
-        let is_timeout = ns
+        let now = self.status.timer.try_now().map_err(TimeError::from)?;
+        let is_timeout = self
+            .status
             .reg_start_time
             .and_then(|ref reg_start_time| {
                 now.checked_duration_since(reg_start_time)
@@ -272,7 +252,7 @@ where
             })
             .unwrap_or(false);
 
-        if ns.conn_state == ConnectionState::Connecting && is_timeout {
+        if self.status.conn_state == ConnectionState::Connecting && is_timeout {
             defmt::warn!("Resetting the modem due to the network registration timeout");
 
             return Err(Error::Generic(GenericError::Timeout));
@@ -280,55 +260,54 @@ where
         Ok(())
     }
 
-    pub fn check_registration_state(&self) -> Result<(), Error> {
-        let mut ns = self.status.try_borrow_mut()?;
-
+    pub fn check_registration_state(&mut self) -> Result<(), Error> {
         // Don't do anything if we are actually disconnected by choice
-        if ns.conn_state == ConnectionState::Disconnected {
+        if self.status.conn_state == ConnectionState::Disconnected {
             return Ok(());
         }
 
         // If both (CSD + PSD) is registered, or EPS is registered, we are connected!
-        if (ns.csd.registered() && ns.psd.registered()) || ns.eps.registered() {
-            ns.set_connection_state(ConnectionState::Connected);
-        } else if ns.conn_state == ConnectionState::Connected {
+        if (self.status.csd.registered() && self.status.psd.registered())
+            || self.status.eps.registered()
+        {
+            self.status.set_connection_state(ConnectionState::Connected);
+        } else if self.status.conn_state == ConnectionState::Connected {
             // FIXME: potentially go back into connecting state only when getting into
             // a 'sticky' non-registered state
-            ns.reset();
-            ns.set_connection_state(ConnectionState::Connecting);
+            self.status.reset();
+            self.status
+                .set_connection_state(ConnectionState::Connecting);
         }
 
         Ok(())
     }
 
-    pub fn intervene_registration(&self) -> Result<(), Error>
+    pub fn intervene_registration(&mut self) -> Result<(), Error>
     where
         Generic<CLK::T>: TryInto<Milliseconds>,
     {
-        let mut ns = self.status.try_borrow_mut()?;
-
-        if ns.conn_state != ConnectionState::Connecting {
+        if self.status.conn_state != ConnectionState::Connecting {
             return Ok(());
         }
 
-        let now = ns.timer.try_now().map_err(TimeError::from)?;
+        let now = self.status.timer.try_now().map_err(TimeError::from)?;
 
         // If EPS has been sticky for longer than `timeout`
-        let timeout = Seconds(ns.registration_interventions * 15);
-        if ns.eps.sticky() && ns.eps.duration(now) >= timeout {
+        let timeout = Seconds(self.status.registration_interventions * 15);
+        if self.status.eps.sticky() && self.status.eps.duration(now) >= timeout {
             // If (EPS + CSD) is not attempting registration
-            if ns.eps.get_status() == registration::Status::NotRegistering
-                && ns.csd.get_status() == registration::Status::NotRegistering
+            if self.status.eps.get_status() == registration::Status::NotRegistering
+                && self.status.csd.get_status() == registration::Status::NotRegistering
             {
                 defmt::debug!(
                     "Sticky not registering state for {} s, PLMN reselection",
-                    Seconds::<u32>::from(ns.eps.duration(now)).integer()
+                    Seconds::<u32>::from(self.status.eps.duration(now)).integer()
                 );
 
-                ns.csd.reset();
-                ns.psd.reset();
-                ns.eps.reset();
-                ns.registration_interventions += 1;
+                self.status.csd.reset();
+                self.status.psd.reset();
+                self.status.eps.reset();
+                self.status.registration_interventions += 1;
                 self.send_internal(
                     &SetOperatorSelection {
                         mode: OperatorSelectionMode::Automatic,
@@ -340,17 +319,17 @@ where
                 return Ok(());
 
             // If (EPS + CSD) is denied registration
-            } else if ns.eps.get_status() == registration::Status::Denied
-                && ns.csd.get_status() == registration::Status::Denied
+            } else if self.status.eps.get_status() == registration::Status::Denied
+                && self.status.csd.get_status() == registration::Status::Denied
             {
                 defmt::debug!(
                     "Sticky denied state for {} s, RF reset",
-                    Seconds::<u32>::from(ns.eps.duration(now)).integer()
+                    Seconds::<u32>::from(self.status.eps.duration(now)).integer()
                 );
-                ns.csd.reset();
-                ns.psd.reset();
-                ns.eps.reset();
-                ns.registration_interventions += 1;
+                self.status.csd.reset();
+                self.status.psd.reset();
+                self.status.eps.reset();
+                self.status.registration_interventions += 1;
                 self.send_internal(
                     &SetModuleFunctionality {
                         fun: Functionality::Minimum,
@@ -371,19 +350,19 @@ where
 
         // If CSD has been sticky for longer than `timeout`,
         // and (CSD + PSD) is denied registration.
-        if ns.csd.sticky()
-            && ns.csd.duration(now) >= timeout
-            && ns.csd.get_status() == registration::Status::Denied
-            && ns.psd.get_status() == registration::Status::Denied
+        if self.status.csd.sticky()
+            && self.status.csd.duration(now) >= timeout
+            && self.status.csd.get_status() == registration::Status::Denied
+            && self.status.psd.get_status() == registration::Status::Denied
         {
             defmt::debug!(
                 "Sticky CSD and PSD denied state for {} s, RF reset",
-                Seconds::<u32>::from(ns.csd.duration(now)).integer()
+                Seconds::<u32>::from(self.status.csd.duration(now)).integer()
             );
-            ns.csd.reset();
-            ns.psd.reset();
-            ns.eps.reset();
-            ns.registration_interventions += 1;
+            self.status.csd.reset();
+            self.status.psd.reset();
+            self.status.eps.reset();
+            self.status.registration_interventions += 1;
             self.send_internal(
                 &SetModuleFunctionality {
                     fun: Functionality::Minimum,
@@ -403,18 +382,18 @@ where
 
         // If CSD is registered, but PSD has been sticky for longer than `timeout`,
         // and (PSD + EPS) is not attempting registration.
-        if ns.csd.registered()
-            && ns.psd.sticky()
-            && ns.psd.duration(now) >= timeout
-            && ns.psd.get_status() == registration::Status::NotRegistering
-            && ns.eps.get_status() == registration::Status::NotRegistering
+        if self.status.csd.registered()
+            && self.status.psd.sticky()
+            && self.status.psd.duration(now) >= timeout
+            && self.status.psd.get_status() == registration::Status::NotRegistering
+            && self.status.eps.get_status() == registration::Status::NotRegistering
         {
             defmt::debug!(
                 "Sticky not registering PSD state for {} s, force GPRS attach",
-                Seconds::<u32>::from(ns.psd.duration(now)).integer()
+                Seconds::<u32>::from(self.status.psd.duration(now)).integer()
             );
-            ns.psd.reset();
-            ns.registration_interventions += 1;
+            self.status.psd.reset();
+            self.status.registration_interventions += 1;
             self.send_internal(&GetPDPContextState, true)?;
 
             if self
@@ -427,9 +406,9 @@ where
                 )
                 .is_err()
             {
-                ns.csd.reset();
-                ns.psd.reset();
-                ns.eps.reset();
+                self.status.csd.reset();
+                self.status.psd.reset();
+                self.status.eps.reset();
                 defmt::warn!("GPRS attach failed, try PLMN reselection");
                 self.send_internal(
                     &SetOperatorSelection {
@@ -444,26 +423,29 @@ where
         Ok(())
     }
 
-    pub fn update_registration(&self) -> Result<(), Error> {
-        let mut status = self.status.try_borrow_mut()?;
-        let ts = status.timer.try_now().map_err(TimeError::from)?;
+    pub fn update_registration(&mut self) -> Result<(), Error> {
+        let ts = self.status.timer.try_now().map_err(TimeError::from)?;
 
         if let Ok(reg) = self.send_internal(&GetNetworkRegistrationStatus, false) {
-            status.compare_and_set(reg.into(), ts);
+            self.status.compare_and_set(reg.into(), ts);
         }
 
         if let Ok(reg) = self.send_internal(&GetGPRSNetworkRegistrationStatus, false) {
-            status.compare_and_set(reg.into(), ts);
+            self.status.compare_and_set(reg.into(), ts);
         }
 
         if let Ok(reg) = self.send_internal(&GetEPSNetworkRegistrationStatus, false) {
-            status.compare_and_set(reg.into(), ts);
+            self.status.compare_and_set(reg.into(), ts);
         }
 
         Ok(())
     }
 
-    pub(crate) fn handle_urc(&self) -> Result<(), Error> {
+    pub(crate) fn handle_urc(&mut self) -> Result<(), Error> {
+        // TODO: How to do this cleaner?
+        let mut ctx_state = self.context_state;
+        let mut new_reg_params: Option<RegistrationParams> = None;
+
         self.at_tx.handle_urc(|urc| {
             match urc {
                 Urc::NetworkDetach => {
@@ -490,38 +472,26 @@ where
                     defmt::info!("[URC] ExtendedPSNetworkRegistration {}", state);
                 }
                 Urc::GPRSNetworkRegistration(reg_params) => {
-                    if let Ok(mut params) = self.status.try_borrow_mut() {
-                        if let Ok(ts) = params.timer.try_now() {
-                            params.compare_and_set(reg_params.into(), ts)
-                        }
-                    }
+                    new_reg_params.replace(reg_params.into());
                 }
                 Urc::EPSNetworkRegistration(reg_params) => {
-                    if let Ok(mut params) = self.status.try_borrow_mut() {
-                        if let Ok(ts) = params.timer.try_now() {
-                            params.compare_and_set(reg_params.into(), ts)
-                        }
-                    }
+                    new_reg_params.replace(reg_params.into());
                 }
                 Urc::NetworkRegistration(reg_params) => {
-                    if let Ok(mut params) = self.status.try_borrow_mut() {
-                        if let Ok(ts) = params.timer.try_now() {
-                            params.compare_and_set(reg_params.into(), ts)
-                        }
-                    }
+                    new_reg_params.replace(reg_params.into());
                 }
                 Urc::DataConnectionActivated(psn::urc::DataConnectionActivated {
                     result,
                     ip_addr: _,
                 }) => {
                     defmt::info!("[URC] DataConnectionActivated {=u8}", result);
-                    self.context_state.set(ContextState::Active);
+                    ctx_state = ContextState::Active;
                 }
                 Urc::DataConnectionDeactivated(psn::urc::DataConnectionDeactivated {
                     profile_id,
                 }) => {
                     defmt::info!("[URC] DataConnectionDeactivated {}", profile_id);
-                    self.context_state.set(ContextState::Activating);
+                    ctx_state = ContextState::Activating;
                 }
                 Urc::MessageWaitingIndication(_) => {
                     defmt::info!("[URC] MessageWaitingIndication");
@@ -529,11 +499,19 @@ where
                 _ => return false,
             };
             true
-        })
+        })?;
+
+        if let Some(reg_params) = new_reg_params {
+            let ts = self.status.timer.try_now().map_err(TimeError::from)?;
+            self.status.compare_and_set(reg_params, ts)
+        }
+
+        self.context_state = ctx_state;
+        Ok(())
     }
 
     pub(crate) fn send_internal<A, const LEN: usize>(
-        &self,
+        &mut self,
         req: &A,
         check_urc: bool,
     ) -> Result<A::Response, Error>
@@ -568,116 +546,126 @@ mod tests {
         // Setup
         let tx = AtTx::new(MockAtClient::new(0), 5);
         let timer = MockTimer::new(Some(25_234));
-        let network = Network::new(tx, timer);
-        let mut ns = network.status.borrow_mut();
-        ns.conn_state = ConnectionState::Connecting;
+        let mut network = Network::new(tx, timer);
+        network.status.conn_state = ConnectionState::Connecting;
         // Update both started & updated
-        ns.eps
+        network
+            .status
+            .eps
             .set_status(Status::NotRegistering, Instant::new(1234));
         // Update only updated
-        ns.eps
+        network
+            .status
+            .eps
             .set_status(Status::NotRegistering, Instant::new(1534));
-        ns.csd
+        network
+            .status
+            .csd
             .set_status(Status::NotRegistering, Instant::new(1534));
 
-        assert_eq!(ns.eps.updated(), Some(Instant::new(1534)));
-        assert_eq!(ns.eps.started(), Some(Instant::new(1234)));
-        assert!(ns.eps.sticky());
+        assert_eq!(network.status.eps.updated(), Some(Instant::new(1534)));
+        assert_eq!(network.status.eps.started(), Some(Instant::new(1234)));
+        assert!(network.status.eps.sticky());
 
-        let ts = ns.timer.try_now().unwrap();
-        assert_eq!(ns.eps.duration(ts), Milliseconds(24_000_u32));
-        drop(ns);
+        let ts = network.status.timer.try_now().unwrap();
+        assert_eq!(network.status.eps.duration(ts), Milliseconds(24_000_u32));
 
         assert!(network.intervene_registration().is_ok());
 
-        let ns = network.status.borrow();
-        assert_eq!(ns.registration_interventions, 2);
+        assert_eq!(network.status.registration_interventions, 2);
     }
 
     #[test]
     fn reset_reg_time() {
         let tx = AtTx::new(MockAtClient::new(0), 5);
         let timer = MockTimer::new(Some(1234));
-        let network = Network::new(tx, timer);
+        let mut network = Network::new(tx, timer);
 
         assert!(network.reset_reg_time().is_ok());
 
-        let ns = network.status.borrow();
-        assert_eq!(ns.reg_start_time, Some(Instant::new(1234)));
-        assert_eq!(ns.reg_check_time, Some(Instant::new(1234)));
+        assert_eq!(network.status.reg_start_time, Some(Instant::new(1234)));
+        assert_eq!(network.status.reg_check_time, Some(Instant::new(1234)));
     }
 
     #[test]
     fn check_registration_state() {
         let tx = AtTx::new(MockAtClient::new(0), 5);
         let timer = MockTimer::new(Some(1234));
-        let network = Network::new(tx, timer);
+        let mut network = Network::new(tx, timer);
 
         // Check that `ConnectionState` will change from `Connected` to `Connecting`
         // with a state reset, if neither (csd + psd) || eps is actually registered
-        let mut ns = network.status.borrow_mut();
-        ns.conn_state = ConnectionState::Connected;
-        ns.registration_interventions = 3;
-        ns.csd.set_status(Status::Denied, Instant::new(1));
-        ns.eps.set_status(Status::NotRegistering, Instant::new(5));
-        drop(ns);
+        network.status.conn_state = ConnectionState::Connected;
+        network.status.registration_interventions = 3;
+        network
+            .status
+            .csd
+            .set_status(Status::Denied, Instant::new(1));
+        network
+            .status
+            .eps
+            .set_status(Status::NotRegistering, Instant::new(5));
 
         assert!(network.check_registration_state().is_ok());
 
-        let mut ns = network.status.borrow_mut();
-        assert_eq!(ns.conn_state, ConnectionState::Connecting);
-        assert_eq!(ns.reg_start_time, Some(Instant::new(1234)));
-        assert_eq!(ns.reg_check_time, Some(Instant::new(1234)));
-        assert_eq!(ns.csd.get_status(), Status::None);
-        assert_eq!(ns.csd.updated(), None);
-        assert_eq!(ns.csd.started(), None);
-        assert_eq!(ns.psd.get_status(), Status::None);
-        assert_eq!(ns.psd.updated(), None);
-        assert_eq!(ns.psd.started(), None);
-        assert_eq!(ns.eps.get_status(), Status::None);
-        assert_eq!(ns.eps.updated(), None);
-        assert_eq!(ns.eps.started(), None);
+        assert_eq!(network.status.conn_state, ConnectionState::Connecting);
+        assert_eq!(network.status.reg_start_time, Some(Instant::new(1234)));
+        assert_eq!(network.status.reg_check_time, Some(Instant::new(1234)));
+        assert_eq!(network.status.csd.get_status(), Status::None);
+        assert_eq!(network.status.csd.updated(), None);
+        assert_eq!(network.status.csd.started(), None);
+        assert_eq!(network.status.psd.get_status(), Status::None);
+        assert_eq!(network.status.psd.updated(), None);
+        assert_eq!(network.status.psd.started(), None);
+        assert_eq!(network.status.eps.get_status(), Status::None);
+        assert_eq!(network.status.eps.updated(), None);
+        assert_eq!(network.status.eps.started(), None);
 
         // Check that `ConnectionState` will change from `Connecting` to `Connected`
         // if eps is actually registered
-        ns.eps.set_status(Status::Roaming, Instant::new(5));
-        drop(ns);
+        network
+            .status
+            .eps
+            .set_status(Status::Roaming, Instant::new(5));
 
         assert!(network.check_registration_state().is_ok());
 
-        let mut ns = network.status.borrow_mut();
-        assert_eq!(ns.conn_state, ConnectionState::Connected);
+        assert_eq!(network.status.conn_state, ConnectionState::Connected);
 
         // Check that `ConnectionState` will change from `Connecting` to `Connected`
         // if (csd + psd) is actually registered
-        ns.conn_state = ConnectionState::Connecting;
-        ns.reset();
-        ns.eps.set_status(Status::Denied, Instant::new(5));
-        ns.csd.set_status(Status::Roaming, Instant::new(5));
-        ns.psd.set_status(Status::Home, Instant::new(5));
-        drop(ns);
+        network.status.conn_state = ConnectionState::Connecting;
+        network.status.reset();
+        network
+            .status
+            .eps
+            .set_status(Status::Denied, Instant::new(5));
+        network
+            .status
+            .csd
+            .set_status(Status::Roaming, Instant::new(5));
+        network.status.psd.set_status(Status::Home, Instant::new(5));
 
         assert!(network.check_registration_state().is_ok());
 
-        let ns = network.status.borrow_mut();
-        assert_eq!(ns.conn_state, ConnectionState::Connected);
+        assert_eq!(network.status.conn_state, ConnectionState::Connected);
     }
 
     #[test]
     fn unhandled_urcs() {
-        let tx = AtTx::new(MockAtClient::new(0), 5);
+        let mut tx = AtTx::new(MockAtClient::new(0), 5);
 
         tx.handle_urc(|_| false).unwrap();
-        assert_eq!(tx.client.borrow().n_urcs_dequeued, 0);
+        assert_eq!(tx.client.n_urcs_dequeued, 0);
         tx.handle_urc(|_| false).unwrap();
         tx.handle_urc(|_| false).unwrap();
         tx.handle_urc(|_| false).unwrap();
         tx.handle_urc(|_| false).unwrap();
         tx.handle_urc(|_| false).unwrap();
-        assert_eq!(tx.client.borrow().n_urcs_dequeued, 1);
+        assert_eq!(tx.client.n_urcs_dequeued, 1);
         tx.handle_urc(|_| false).unwrap();
         tx.handle_urc(|_| true).unwrap();
         tx.handle_urc(|_| false).unwrap();
-        assert_eq!(tx.client.borrow().n_urcs_dequeued, 2);
+        assert_eq!(tx.client.n_urcs_dequeued, 2);
     }
 }

--- a/ublox-cellular/src/power.rs
+++ b/ublox-cellular/src/power.rs
@@ -44,7 +44,7 @@ where
     /// See if the cellular module is responding at the AT interface by poking
     /// it with "AT" up to `attempts` times, waiting 1 second for an "OK"
     /// response each time
-    pub(crate) fn is_alive(&self, attempts: u8) -> Result<(), Error> {
+    pub(crate) fn is_alive(&mut self, attempts: u8) -> Result<(), Error> {
         let mut error = Error::BaudDetection;
         for _ in 0..attempts {
             match self.network.at_tx.send_ignore_timeout(&AT) {
@@ -123,7 +123,6 @@ where
 
                 self.network
                     .status
-                    .try_borrow()?
                     .timer
                     .new_timer(50.milliseconds())
                     .start()?
@@ -132,7 +131,6 @@ where
                 rst.try_set_high().ok();
                 self.network
                     .status
-                    .try_borrow()?
                     .timer
                     .new_timer(1.seconds())
                     .start()?
@@ -166,7 +164,6 @@ where
                     pwr.try_set_low().ok();
                     self.network
                         .status
-                        .try_borrow()?
                         .timer
                         .new_timer(50.microseconds())
                         .start()?
@@ -174,7 +171,6 @@ where
                     pwr.try_set_high().ok();
                     self.network
                         .status
-                        .try_borrow()?
                         .timer
                         .new_timer(1.seconds())
                         .start()?
@@ -210,7 +206,6 @@ where
 
         self.network
             .status
-            .try_borrow()?
             .timer
             .new_timer(10.seconds())
             .start()?
@@ -229,7 +224,6 @@ where
                     pwr.try_set_low().ok();
                     self.network
                         .status
-                        .try_borrow()?
                         .timer
                         .new_timer(1.seconds())
                         .start()?
@@ -241,7 +235,6 @@ where
 
                     self.network
                         .status
-                        .try_borrow()?
                         .timer
                         .new_timer(10.seconds())
                         .start()?
@@ -283,7 +276,7 @@ where
     where
         Generic<CLK::T>: TryInto<Milliseconds>,
     {
-        let now = self.network.status.try_borrow()?.timer.try_now().unwrap();
+        let now = self.network.status.timer.try_now().unwrap();
 
         let mut res = false;
 
@@ -291,7 +284,6 @@ where
         while self
             .network
             .status
-            .try_borrow()?
             .timer
             .try_now()
             .ok()
@@ -307,7 +299,6 @@ where
 
             self.network
                 .status
-                .try_borrow()?
                 .timer
                 .new_timer(5.milliseconds())
                 .start()?

--- a/ublox-cellular/src/services/data/dns.rs
+++ b/ublox-cellular/src/services/data/dns.rs
@@ -15,7 +15,7 @@ where
 {
     type Error = Error;
 
-    fn get_host_by_address(&self, ip_addr: IpAddr) -> nb::Result<String<256>, Self::Error> {
+    fn get_host_by_address(&mut self, ip_addr: IpAddr) -> nb::Result<String<256>, Self::Error> {
         let mut ip_str = String::<256>::new();
         write!(&mut ip_str, "{}", ip_addr).map_err(|_| Error::BadLength)?;
 
@@ -34,7 +34,7 @@ where
     }
 
     fn get_host_by_name(
-        &self,
+        &mut self,
         hostname: &str,
         addr_type: AddrType,
     ) -> nb::Result<IpAddr, Self::Error> {

--- a/ublox-cellular/src/services/data/error.rs
+++ b/ublox-cellular/src/services/data/error.rs
@@ -3,7 +3,6 @@ use embedded_time::TimeError;
 use super::socket::Error as SocketError;
 use crate::error::GenericError;
 use crate::network::Error as NetworkError;
-use core::cell::{BorrowError, BorrowMutError};
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -37,18 +36,6 @@ impl From<NetworkError> for Error {
 impl From<SocketError> for Error {
     fn from(e: SocketError) -> Self {
         Error::Socket(e)
-    }
-}
-
-impl From<BorrowMutError> for Error {
-    fn from(e: BorrowMutError) -> Self {
-        Error::Generic(e.into())
-    }
-}
-
-impl From<BorrowError> for Error {
-    fn from(e: BorrowError) -> Self {
-        Error::Generic(e.into())
     }
 }
 

--- a/ublox-cellular/src/services/data/ssl.rs
+++ b/ublox-cellular/src/services/data/ssl.rs
@@ -28,8 +28,11 @@ pub trait SSL {
         private_key: &[u8],
         password: Option<&str>,
     ) -> Result<(), Error>;
-    fn enable_ssl(&mut self, profile_id: SecurityProfileId, server_hostname: &str)
-        -> Result<(), Error>;
+    fn enable_ssl(
+        &mut self,
+        profile_id: SecurityProfileId,
+        server_hostname: &str,
+    ) -> Result<(), Error>;
 }
 
 impl<'a, C, CLK, const N: usize, const L: usize> SSL for DataService<'a, C, CLK, N, L>

--- a/ublox-cellular/src/services/data/ssl.rs
+++ b/ublox-cellular/src/services/data/ssl.rs
@@ -10,25 +10,25 @@ pub struct SecurityProfileId(pub u8);
 
 pub trait SSL {
     fn import_certificate(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         name: &str,
         certificate: &[u8],
     ) -> Result<(), Error>;
     fn import_root_ca(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         name: &str,
         root_ca: &[u8],
     ) -> Result<(), Error>;
     fn import_private_key(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         name: &str,
         private_key: &[u8],
         password: Option<&str>,
     ) -> Result<(), Error>;
-    fn enable_ssl(&self, profile_id: SecurityProfileId, server_hostname: &str)
+    fn enable_ssl(&mut self, profile_id: SecurityProfileId, server_hostname: &str)
         -> Result<(), Error>;
 }
 
@@ -38,7 +38,7 @@ where
     CLK: Clock,
 {
     fn import_certificate(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         name: &str,
         certificate: &[u8],
@@ -76,7 +76,7 @@ where
     }
 
     fn import_root_ca(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         name: &str,
         root_ca: &[u8],
@@ -116,7 +116,7 @@ where
     }
 
     fn import_private_key(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         name: &str,
         private_key: &[u8],
@@ -155,7 +155,7 @@ where
     }
 
     fn enable_ssl(
-        &self,
+        &mut self,
         profile_id: SecurityProfileId,
         server_hostname: &str,
     ) -> Result<(), Error> {

--- a/ublox-cellular/src/services/data/tcp_stack.rs
+++ b/ublox-cellular/src/services/data/tcp_stack.rs
@@ -61,7 +61,8 @@ where
         socket: &mut Self::TcpSocket,
         remote: SocketAddr,
     ) -> nb::Result<(), Self::Error> {
-        let mut tcp = self.sockets
+        let mut tcp = self
+            .sockets
             .get::<TcpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
 
@@ -97,7 +98,10 @@ where
 
     /// Check if this socket is still connected
     fn is_connected(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error> {
-        Ok(self.sockets.get::<TcpSocket<CLK, L>>(*socket)?.is_connected())
+        Ok(self
+            .sockets
+            .get::<TcpSocket<CLK, L>>(*socket)?
+            .is_connected())
     }
 
     /// Write to the stream. Returns the number of bytes written is returned
@@ -152,7 +156,8 @@ where
         socket: &mut Self::TcpSocket,
         buffer: &mut [u8],
     ) -> nb::Result<usize, Self::Error> {
-        let mut tcp = self.sockets
+        let mut tcp = self
+            .sockets
             .get::<TcpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
 

--- a/ublox-cellular/src/services/data/udp_stack.rs
+++ b/ublox-cellular/src/services/data/udp_stack.rs
@@ -58,7 +58,8 @@ where
         socket: &mut Self::UdpSocket,
         remote: SocketAddr,
     ) -> Result<(), Self::Error> {
-        let mut udp = self.sockets
+        let mut udp = self
+            .sockets
             .get::<UdpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
         udp.bind(remote).map_err(Self::Error::from)?;
@@ -67,7 +68,8 @@ where
 
     /// Send a datagram to the remote host.
     fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error> {
-        let udp = self.sockets
+        let udp = self
+            .sockets
             .get::<UdpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
 
@@ -118,8 +120,8 @@ where
         socket: &mut Self::UdpSocket,
         buffer: &mut [u8],
     ) -> nb::Result<(usize, SocketAddr), Self::Error> {
-
-        let mut udp = self.sockets
+        let mut udp = self
+            .sockets
             .get::<UdpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
 

--- a/ublox-cellular/src/services/data/udp_stack.rs
+++ b/ublox-cellular/src/services/data/udp_stack.rs
@@ -30,13 +30,11 @@ where
     /// Open a new UDP socket to the given address and port. UDP is connectionless,
     /// so unlike `TcpStack` no `connect()` is required.
     fn socket(&mut self) -> Result<Self::UdpSocket, Self::Error> {
-        let mut sockets = self.sockets.try_borrow_mut()?;
-
-        if sockets.len() >= sockets.capacity() {
-            if let Ok(ts) = self.network.status.try_borrow_mut()?.timer.try_now() {
+        if self.sockets.len() >= self.sockets.capacity() {
+            if let Ok(ts) = self.network.status.timer.try_now() {
                 // Check if there are any sockets closed by remote, and close it
                 // if it has exceeded its timeout, in order to recycle it.
-                if sockets.recycle(&ts) {
+                if self.sockets.recycle(&ts) {
                     return Err(Error::Socket(SocketError::SocketSetFull));
                 }
             } else {
@@ -52,7 +50,7 @@ where
             false,
         )?;
 
-        Ok(sockets.add(UdpSocket::new(socket_resp.socket.0))?)
+        Ok(self.sockets.add(UdpSocket::new(socket_resp.socket.0))?)
     }
 
     fn connect(
@@ -60,9 +58,7 @@ where
         socket: &mut Self::UdpSocket,
         remote: SocketAddr,
     ) -> Result<(), Self::Error> {
-        let mut sockets = self.sockets.try_borrow_mut().map_err(Self::Error::from)?;
-
-        let mut udp = sockets
+        let mut udp = self.sockets
             .get::<UdpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
         udp.bind(remote).map_err(Self::Error::from)?;
@@ -71,9 +67,7 @@ where
 
     /// Send a datagram to the remote host.
     fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error> {
-        let mut sockets = self.sockets.try_borrow_mut().map_err(Self::Error::from)?;
-
-        let udp = sockets
+        let udp = self.sockets
             .get::<UdpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
 
@@ -124,9 +118,8 @@ where
         socket: &mut Self::UdpSocket,
         buffer: &mut [u8],
     ) -> nb::Result<(usize, SocketAddr), Self::Error> {
-        let mut sockets = self.sockets.try_borrow_mut().map_err(Self::Error::from)?;
 
-        let mut udp = sockets
+        let mut udp = self.sockets
             .get::<UdpSocket<CLK, L>>(*socket)
             .map_err(Self::Error::from)?;
 
@@ -140,7 +133,7 @@ where
     /// Close an existing UDP socket.
     fn close(&mut self, socket: Self::UdpSocket) -> Result<(), Self::Error> {
         self.network.send_internal(&CloseSocket { socket }, false)?;
-        self.sockets.try_borrow_mut()?.remove(socket)?;
+        self.sockets.remove(socket)?;
         Ok(())
     }
 }


### PR DESCRIPTION
With the updated embedded-nal, all the RefCells & Cells in this crate is unnecessary. These are now removed in favor of mutable self references.

**NOTE**: 
~~Dependent on new release of embedded-nal with mutable DNS trait.~~