### PR TITLE
Allow users to reconfigure peripheral baudrate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,11 +3,6 @@
     // "can't find crate for `test`" when the default compilation target is a no_std target
     // with these changes RA will call `cargo check --bins` on save
     "rust-analyzer.checkOnSave.allTargets": false,
-    "rust-analyzer.checkOnSave.extraArgs": [
-        "-bins",
-        "--target",
-        "x86_64-unknown-linux-gnu"
-    ],
     "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
     "rust-analyzer.diagnostics.disabled": [
         "unresolved-import"

--- a/ublox-cellular/src/command/control/mod.rs
+++ b/ublox-cellular/src/command/control/mod.rs
@@ -4,9 +4,11 @@
 //! (depending on the +CMEE AT command setting).
 // pub mod responses;
 pub mod types;
+pub mod responses;
 
-use atat::atat_derive::AtatCmd;
+use atat::{atat_derive::AtatCmd};
 use types::*;
+use responses::*;
 
 use super::NoResponse;
 
@@ -81,6 +83,14 @@ pub struct SetDataRate {
     pub rate: BaudRate,
 }
 
+/// 15.9 UART data rate configuration +IPR
+///
+/// Returns the data rate at which the DCE accepts commands on the UART
+/// interface.
+#[derive(Clone, AtatCmd)]
+#[at_cmd("+IPR?", DataRate)]
+pub struct GetDataRate;
+
 /// 15.25 Set to factory defined configuration &F
 ///
 /// Resets the current profile to factory-programmed setting. Other NVM
@@ -92,3 +102,14 @@ pub struct SetDataRate {
 #[derive(Clone, AtatCmd)]
 #[at_cmd("&F", NoResponse)]
 pub struct FactoryResetConfig;
+
+/// 15.26.1 Description
+/// 
+/// Stores into one of the two RAM profile mirrors the current AT configuration of the DCE interface in which the
+/// command is issued. The profile is selected according to the AT command parameter value. 
+#[derive(Clone, AtatCmd)]
+#[at_cmd("&W", NoResponse, value_sep = false)]
+pub struct StoreCurrentConfig{
+    #[at_arg(position = 0)]
+    pub profile: u8,
+}

--- a/ublox-cellular/src/command/control/responses.rs
+++ b/ublox-cellular/src/command/control/responses.rs
@@ -1,0 +1,11 @@
+use atat::atat_derive::AtatResp;
+
+/// 15.9 UART data rate configuration +IPR
+///
+/// Returns the data rate at which the DCE accepts commands on the UART
+/// interface.
+#[derive(Clone, Debug, AtatResp)]
+pub struct DataRate {
+    #[at_arg(position = 0)]
+    pub data_rate: u32,
+}

--- a/ublox-cellular/src/command/control/types.rs
+++ b/ublox-cellular/src/command/control/types.rs
@@ -51,7 +51,7 @@ pub enum SoftwareFlowControl {
     Circuit105_106 = 3,
 }
 
-#[derive(Clone, PartialEq, AtatEnum)]
+#[derive(Clone, PartialEq, AtatEnum, Debug, Copy)]
 #[at_enum(u32)]
 pub enum BaudRate {
     #[cfg(any(
@@ -133,4 +133,95 @@ pub enum BaudRate {
     B6000000 = 6_000_000,
     #[cfg(any(feature = "toby-r2", feature = "lara-r2",))]
     B6500000 = 6_500_000,
+}
+
+impl core::convert::TryFrom<u32> for BaudRate {
+    type Error = ();
+
+    // TODO: replace this impl with https://github.com/BlackbirdHQ/atat/pull/111/files
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        let res = match value {
+            #[cfg(any(
+                feature = "toby-l2",
+                feature = "mpci-l2",
+                feature = "sara-u2",
+                feature = "toby-r2",
+                feature = "lara-r2",
+                feature = "toby-l4",
+                feature = "leon-g1",
+                feature = "sara-g3",
+                feature = "sara-g4"
+            ))]
+            0 => Self::B0,
+            #[cfg(any(feature = "lisa-u1", feature = "lisa-u2", feature = "sara-u2",))]
+            1200 => Self::B1200,
+            #[cfg(any(
+                feature = "lisa-u1",
+                feature = "lisa-u2",
+                feature = "sara-u2",
+                feature = "leon-g1",
+                feature = "sara-g3",
+                feature = "sara-g4"
+            ))]
+            2400 => Self::B2400,
+            #[cfg(any(
+                feature = "lisa-u1",
+                feature = "lisa-u2",
+                feature = "sara-u2",
+                feature = "leon-g1",
+                feature = "sara-g3",
+                feature = "sara-g4"
+            ))]
+            4800 => Self::B4800,
+            9600 => Self::B9600,
+            19200 => Self::B19200,
+            38400 => Self::B38400,
+            57600 => Self::B57600,
+            115200 => Self::B115200,
+            #[cfg(any(
+                feature = "toby-l2",
+                feature = "mpci-l2",
+                feature = "lisa-u1",
+                feature = "lisa-u2",
+                feature = "sara-u2",
+                feature = "toby-r2",
+                feature = "lara-r2",
+                feature = "toby-l4",
+            ))]
+            230400 => Self::B230400,
+            #[cfg(any(
+                feature = "toby-l2",
+                feature = "mpci-l2",
+                feature = "lisa-u1",
+                feature = "lisa-u2",
+                feature = "sara-u2",
+                feature = "toby-r2",
+                feature = "lara-r2",
+                feature = "toby-l4",
+            ))]
+            460800 => Self::B460800,
+            #[cfg(any(
+                feature = "toby-l2",
+                feature = "mpci-l2",
+                feature = "lisa-u1",
+                feature = "lisa-u2",
+                feature = "sara-u2",
+                feature = "toby-r2",
+                feature = "lara-r2",
+                feature = "toby-l4",
+            ))]
+            921600 => Self::B921600,
+            #[cfg(any(feature = "toby-r2", feature = "lara-r2",))]
+            3000000 => Self::B3000000,
+            #[cfg(any(feature = "toby-r2", feature = "lara-r2",))]
+            3250000 => Self::B3250000,
+            #[cfg(any(feature = "toby-r2", feature = "lara-r2",))]
+            6000000 => Self::B6000000,
+            #[cfg(any(feature = "toby-r2", feature = "lara-r2",))]
+            6500000 => Self::B6500000,
+            _ => return Err(()),
+        };
+
+        Ok(res)
+    }
 }

--- a/ublox-cellular/src/command/general/responses.rs
+++ b/ublox-cellular/src/command/general/responses.rs
@@ -26,6 +26,12 @@ pub struct FirmwareVersion {
     pub version: CharVec<10>,
 }
 
+impl defmt::Format for FirmwareVersion {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{}", self.version.to_string().as_str());
+    }
+}
+
 /// 4.7 IMEI identification +CGSN
 ///
 /// Returns the product serial number, the International Mobile Equipment
@@ -43,6 +49,12 @@ pub struct IMEI {
 #[derive(Clone, Debug, AtatResp)]
 pub struct IdentificationInformationResponse {
     pub app_ver: CharVec<32>,
+}
+
+impl defmt::Format for IdentificationInformationResponse {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{}", self.app_ver.to_string().as_str());
+    }
 }
 
 /// 4.11 International mobile subscriber identification +CIM

--- a/ublox-cellular/src/config.rs
+++ b/ublox-cellular/src/config.rs
@@ -1,4 +1,4 @@
-use crate::APNInfo;
+use crate::{APNInfo};
 use embedded_hal::digital::{InputPin, OutputPin};
 use heapless::String;
 

--- a/ublox-cellular/src/error.rs
+++ b/ublox-cellular/src/error.rs
@@ -1,5 +1,6 @@
 use embedded_time::TimeError;
 
+use crate::command::control::types::BaudRate;
 use crate::network::Error as NetworkError;
 use crate::services::data::Error as DataServiceError;
 
@@ -24,6 +25,10 @@ pub enum Error {
     Busy,
     Uninitialized,
     StateTimeout,
+
+    /// The device was reconfigured for a new baud rate.
+    /// Caller should reconfigure it's UART interface to this rate.
+    NeedsBaudReconnect(BaudRate),
 
     // Network errors
     Network(NetworkError),

--- a/ublox-cellular/src/network.rs
+++ b/ublox-cellular/src/network.rs
@@ -213,6 +213,7 @@ where
         Generic<CLK::T>: TryInto<Milliseconds>,
     {
         if self.at_tx.consecutive_timeouts > 10 {
+            self.at_tx.consecutive_timeouts = 0;
             defmt::warn!("Resetting the modem due to consecutive AT timeouts");
             return Err(Error::Generic(GenericError::Timeout));
         }
@@ -520,8 +521,8 @@ where
         A::Error: Into<UbloxError>,
     {
         if check_urc {
-            if let Err(e) = self.handle_urc() {
-                defmt::error!("Failed handle URC  {}", defmt::Debug2Format(&e));
+            if let Err(_) = self.handle_urc() {
+                defmt::error!("Failed handle URC");
             }
         }
 

--- a/ublox-cellular/src/power.rs
+++ b/ublox-cellular/src/power.rs
@@ -129,7 +129,7 @@ where
                 self.network
                     .status
                     .timer
-                    .new_timer(1.seconds())
+                    .new_timer(5.seconds())
                     .start()?
                     .wait()?;
             }
@@ -173,7 +173,7 @@ where
                         .start()?
                         .wait()?;
 
-                    if let Err(e) = self.wait_power_state(PowerState::On, 5_000u32.milliseconds()) {
+                    if let Err(e) = self.wait_power_state(PowerState::On, 25_000u32.milliseconds()) {
                         defmt::error!("Failed to power on modem");
                         return Err(e);
                     } else {
@@ -251,12 +251,15 @@ where
     pub fn power_state(&mut self) -> Result<PowerState, Error> {
         match self.config.vint_pin {
             Some(ref mut vint) => {
+                defmt::debug!("pin was set, trying to read vint");
                 if vint
                     .try_is_high()
                     .map_err(|_| Error::Generic(GenericError::Unsupported))?
                 {
+                    defmt::trace!("vint: high");
                     Ok(PowerState::On)
                 } else {
+                    defmt::trace!("vint: low");
                     Ok(PowerState::Off)
                 }
             }


### PR DESCRIPTION
Add error return types allowing users to reconfigure UART peripheral baudrates above autobauding limits

Fixes #12 