### PR TITLE
Mark CloseSocket as having timeout of 120s

### DIFF
--- a/ublox-cellular/src/command/ip_transport_layer/mod.rs
+++ b/ublox-cellular/src/command/ip_transport_layer/mod.rs
@@ -65,7 +65,7 @@ pub struct SetSocketSslState {
 /// flag, the final result code is sent immediately. The following +UUSOCL URC
 /// will indicate the closure of the specified socket.
 #[derive(Clone, AtatCmd)]
-#[at_cmd("+USOCL", NoResponse)]
+#[at_cmd("+USOCL", NoResponse, timeout_ms = 120000)]
 pub struct CloseSocket {
     #[at_arg(position = 0)]
     pub socket: SocketHandle,


### PR DESCRIPTION
The spec[1] mentions a response time less than 120s

[1]: https://www.u-blox.com/en/ubx-viewer/view/u-blox-CEL_ATCommands_UBX-13002752?url=https%3A%2F%2Fwww.u-blox.com%2Fsites%2Fdefault%2Ffiles%2Fu-blox-CEL_ATCommands_UBX-13002752.pdf