### PR TITLE
add support for +USECMNG=4,.. to retrieve cert md5

### DIFF
--- a/ublox-cellular/src/command/device_data_security/mod.rs
+++ b/ublox-cellular/src/command/device_data_security/mod.rs
@@ -124,6 +124,22 @@ pub struct SendSecurityDataImport<'a> {
 #[at_cmd("+USECMNG=3", Vec<SecurityData, 3> , value_sep = false)]
 pub struct ListSecurityData;
 
+#[derive(Clone, AtatCmd)]
+#[at_cmd("+USECMNG=4,", SecurityDataImport, value_sep = false)]
+pub struct RetrieveSecurityMd5<'a> {
+    /// Type of the security data
+    #[at_arg(position = 0)]
+    pub data_type: SecurityDataType,
+    /// Unique identifier of an imported certificate or private key. If an
+    /// existing name is used the data will be overridden.
+    ///
+    /// **TOBY-L2 / MPCI-L2 / LARA-R2 / TOBY-R2 / SARA-U2 / LISA-U2 / SARA-G4 /
+    /// SARA-G3:**
+    /// - The maximum length is 200 characters
+    #[at_arg(position = 1, len = 200)]
+    pub internal_name: &'a str,
+}
+
 /// 26.1.3 SSL/TLS security layer profile manager +USECPRF
 ///
 /// Manages security profiles for the configuration of the SSL/TLS connection

--- a/ublox-cellular/src/command/device_data_security/responses.rs
+++ b/ublox-cellular/src/command/device_data_security/responses.rs
@@ -11,7 +11,7 @@ pub struct SecurityDataImport {
     op_code: SecurityOperation,
     /// Type of the security data
     #[at_arg(position = 1)]
-    data_type: SecurityDataType,
+    pub data_type: SecurityDataType,
     /// Unique identifier of an imported certificate or private key. If an
     /// existing name is used the data will be overridden.
     ///
@@ -19,10 +19,10 @@ pub struct SecurityDataImport {
     /// SARA-G3:**
     /// - The maximum length is 200 characters
     #[at_arg(position = 2)]
-    internal_name: String<200>,
+    pub internal_name: String<200>,
     /// MD5 formatted string.
     #[at_arg(position = 3)]
-    md5_string: String<32>,
+    pub md5_string: String<32>,
 }
 
 #[derive(Clone, PartialEq, AtatResp)]


### PR DESCRIPTION
Add struct to support `+USECMNG=4,.` command to retrieve cert MD5. It uses the same `SecurityDataImport` as response where useful fields are now marked as `pub`. In some sense actually all fields should be marked as `pub` as struct itself is `pub`. Also now we can use `at_send` very early (https://github.com/BlackbirdHQ/ublox-cellular-rs/commit/dd00a85099fcfd52e69afc776e0d647bab3063a8) and probably wanna use those structs in user application.
