### PR TITLE
Add is_alive to setup_at_commands and more docs

### DIFF
--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -92,6 +92,8 @@ where
 {
     /// Create new u-blox device
     ///
+    /// Look for [`data_service`](Device::data_service) how to handle data connection automatically.
+    ///
     /// # Examples
     ///
     /// ```ignore
@@ -183,8 +185,10 @@ where
 
     /// Run modem state machine
     ///
-    /// For typical use case only this is needed to manage modem automatically.
-    /// It does everything from turning on the modem, configuring it and managing network connection.
+    /// Turns on modem if needed and processes URCs.
+    /// Typically it is not needed to use it directly. However it can be useful for manually handling network connections.
+    /// For fully automatic data connection handling use [`data_service`](Device::data_service).
+    ///
     /// This must be called periodically in a loop.
     pub fn spin(&mut self) -> nb::Result<(), Error> {
         let res = self.initialize();

--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -244,6 +244,9 @@ where
             self.power_on()?;
         }
 
+        // At this point, if is_alive fails, the configured Baud rate is probably wrong
+        self.is_alive(20).map_err(|_| Error::BaudDetection)?;
+
         // Extended errors on
         self.network.send_internal(
             &SetReportMobileTerminationError {

--- a/ublox-cellular/src/services/data/mod.rs
+++ b/ublox-cellular/src/services/data/mod.rs
@@ -127,6 +127,24 @@ where
         Ok(())
     }
 
+    /// Handle modem data connection
+    ///
+    /// For typical use case only this is needed to manage modem automatically.
+    /// It does everything from turning on the modem, configuring it and managing network connection.
+    /// This must be called periodically in a loop.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// loop {
+    ///     modem.data_service(&APNInfo::new("myapn")).and_then(|mut data_service| {
+    ///         // at this point modem is registered to network and data connection is active
+    ///         //  `data_service` can be use to send / receive data
+    ///
+    ///         Ok(())
+    ///     });
+    /// }
+    /// ```
     pub fn data_service<'a>(
         &'a mut self,
         apn_info: &APNInfo,


### PR DESCRIPTION
This PR adds is_alive() check to setup_at_commands(), it turned out that sometimes AT interface is not yet ready at this point.
I also added more docs to `data_service` to explain that this the most automatic thing to use.