### PR TITLE
Fix(network): remove CREG/CGREG/CEREG URCs for now, as they fail parsing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,12 @@
     // with these changes RA will call `cargo check --bins` on save
     "rust-analyzer.checkOnSave.allTargets": false,
     "rust-analyzer.checkOnSave.extraArgs": [
-        "-bins",
+        "--bins",
         "--target",
         "x86_64-unknown-linux-gnu"
+    ],
+    "rust-analyzer.cargo.features": [
+        "lara-r6",
     ],
     "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
     "rust-analyzer.diagnostics.disabled": [

--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -22,7 +22,7 @@ use crate::{
     command::{
         general::{GetCCID, GetFirmwareVersion, GetModelId},
         gpio::{
-            types::{GpioMode, GpioOutValue},
+            types::{GpioInPull, GpioMode, GpioOutValue},
             SetGpioConfiguration,
         },
         network_service::{
@@ -276,6 +276,14 @@ where
             &SetGpioConfiguration {
                 gpio_id: 25,
                 gpio_mode: GpioMode::Output(GpioOutValue::High),
+            },
+            false,
+        )?;
+
+        self.network.send_internal(
+            &SetGpioConfiguration {
+                gpio_id: 42,
+                gpio_mode: GpioMode::Input(GpioInPull::NoPull),
             },
             false,
         )?;
@@ -554,7 +562,7 @@ where
         // CREG URC
         self.network.send_internal(
             &SetNetworkRegistrationStatus {
-                n: NetworkRegistrationUrcConfig::UrcVerbose,
+                n: NetworkRegistrationUrcConfig::UrcDisabled,
             },
             true,
         )?;
@@ -562,7 +570,7 @@ where
         // CGREG URC
         self.network.send_internal(
             &SetGPRSNetworkRegistrationStatus {
-                n: GPRSNetworkRegistrationUrcConfig::UrcVerbose,
+                n: GPRSNetworkRegistrationUrcConfig::UrcDisabled,
             },
             true,
         )?;
@@ -570,7 +578,7 @@ where
         // CEREG URC
         self.network.send_internal(
             &SetEPSNetworkRegistrationStatus {
-                n: EPSNetworkRegistrationUrcConfig::UrcVerbose,
+                n: EPSNetworkRegistrationUrcConfig::UrcDisabled,
             },
             true,
         )?;

--- a/ublox-cellular/src/command/mod.rs
+++ b/ublox-cellular/src/command/mod.rs
@@ -53,12 +53,12 @@ pub enum Urc {
 
     #[at_urc("+UMWI")]
     MessageWaitingIndication(sms::urc::MessageWaitingIndication),
-    #[at_urc("+CREG")]
-    NetworkRegistration(network_service::urc::NetworkRegistration),
-    #[at_urc("+CGREG")]
-    GPRSNetworkRegistration(psn::urc::GPRSNetworkRegistration),
-    #[at_urc("+CEREG")]
-    EPSNetworkRegistration(psn::urc::EPSNetworkRegistration),
+    // #[at_urc("+CREG")]
+    // NetworkRegistration(network_service::urc::NetworkRegistration),
+    // #[at_urc("+CGREG")]
+    // GPRSNetworkRegistration(psn::urc::GPRSNetworkRegistration),
+    // #[at_urc("+CEREG")]
+    // EPSNetworkRegistration(psn::urc::EPSNetworkRegistration),
     #[at_urc("+UREG")]
     ExtendedPSNetworkRegistration(psn::urc::ExtendedPSNetworkRegistration),
 

--- a/ublox-cellular/src/network.rs
+++ b/ublox-cellular/src/network.rs
@@ -195,7 +195,7 @@ where
 
         self.status.reg_check_time.replace(now);
 
-        // self.update_registration()?;
+        self.update_registration()?;
 
         let now = self.status.timer.now();
         let is_timeout = self
@@ -470,15 +470,15 @@ where
                 }) => {
                     info!("[URC] ExtendedPSNetworkRegistration {:?}", state);
                 }
-                Urc::GPRSNetworkRegistration(reg_params) => {
-                    new_reg_params.replace(reg_params.into());
-                }
-                Urc::EPSNetworkRegistration(reg_params) => {
-                    new_reg_params.replace(reg_params.into());
-                }
-                Urc::NetworkRegistration(reg_params) => {
-                    new_reg_params.replace(reg_params.into());
-                }
+                // Urc::GPRSNetworkRegistration(reg_params) => {
+                //     new_reg_params.replace(reg_params.into());
+                // }
+                // Urc::EPSNetworkRegistration(reg_params) => {
+                //     new_reg_params.replace(reg_params.into());
+                // }
+                // Urc::NetworkRegistration(reg_params) => {
+                //     new_reg_params.replace(reg_params.into());
+                // }
                 Urc::DataConnectionActivated(psn::urc::DataConnectionActivated {
                     result,
                     ip_addr: _,

--- a/ublox-cellular/src/registration.rs
+++ b/ublox-cellular/src/registration.rs
@@ -2,12 +2,12 @@ use crate::command::{
     network_service::{
         responses::NetworkRegistrationStatus,
         types::{NetworkRegistrationStat, RatAct},
-        urc::NetworkRegistration,
+        // urc::NetworkRegistration,
     },
     psn::{
         responses::{EPSNetworkRegistrationStatus, GPRSNetworkRegistrationStatus},
         types::{EPSNetworkRegistrationStat, GPRSNetworkRegistrationStat},
-        urc::{EPSNetworkRegistration, GPRSNetworkRegistration},
+        // urc::{EPSNetworkRegistration, GPRSNetworkRegistration},
     },
 };
 use fugit::{ExtU32, TimerInstantU32};
@@ -308,19 +308,19 @@ where
     }
 }
 
-impl From<NetworkRegistration> for RegistrationParams {
-    fn from(v: NetworkRegistration) -> Self {
-        Self {
-            act: RatAct::Gsm,
-            reg_type: RegType::Creg,
-            status: v.stat.into(),
-            cell_id: None,
-            lac: None,
-            // active_time: None,
-            // periodic_tau: None,
-        }
-    }
-}
+// impl From<NetworkRegistration> for RegistrationParams {
+//     fn from(v: NetworkRegistration) -> Self {
+//         Self {
+//             act: RatAct::Gsm,
+//             reg_type: RegType::Creg,
+//             status: v.stat.into(),
+//             cell_id: None,
+//             lac: None,
+//             // active_time: None,
+//             // periodic_tau: None,
+//         }
+//     }
+// }
 
 impl From<NetworkRegistrationStatus> for RegistrationParams {
     fn from(v: NetworkRegistrationStatus) -> Self {
@@ -336,19 +336,19 @@ impl From<NetworkRegistrationStatus> for RegistrationParams {
     }
 }
 
-impl From<GPRSNetworkRegistration> for RegistrationParams {
-    fn from(v: GPRSNetworkRegistration) -> Self {
-        Self {
-            act: v.act.unwrap_or(RatAct::Unknown),
-            reg_type: RegType::Cgreg,
-            status: v.stat.into(),
-            cell_id: v.ci,
-            lac: v.lac,
-            // active_time: None,
-            // periodic_tau: None,
-        }
-    }
-}
+// impl From<GPRSNetworkRegistration> for RegistrationParams {
+//     fn from(v: GPRSNetworkRegistration) -> Self {
+//         Self {
+//             act: v.act.unwrap_or(RatAct::Unknown),
+//             reg_type: RegType::Cgreg,
+//             status: v.stat.into(),
+//             cell_id: v.ci,
+//             lac: v.lac,
+//             // active_time: None,
+//             // periodic_tau: None,
+//         }
+//     }
+// }
 
 impl From<GPRSNetworkRegistrationStatus> for RegistrationParams {
     fn from(v: GPRSNetworkRegistrationStatus) -> Self {
@@ -364,19 +364,19 @@ impl From<GPRSNetworkRegistrationStatus> for RegistrationParams {
     }
 }
 
-impl From<EPSNetworkRegistration> for RegistrationParams {
-    fn from(v: EPSNetworkRegistration) -> Self {
-        Self {
-            reg_type: RegType::Cereg,
-            status: v.stat.into(),
-            cell_id: v.ci,
-            lac: v.tac,
-            act: v.act.unwrap_or(RatAct::Unknown),
-            // active_time: None,
-            // periodic_tau: None,
-        }
-    }
-}
+// impl From<EPSNetworkRegistration> for RegistrationParams {
+//     fn from(v: EPSNetworkRegistration) -> Self {
+//         Self {
+//             reg_type: RegType::Cereg,
+//             status: v.stat.into(),
+//             cell_id: v.ci,
+//             lac: v.tac,
+//             act: v.act.unwrap_or(RatAct::Unknown),
+//             // active_time: None,
+//             // periodic_tau: None,
+//         }
+//     }
+// }
 
 impl From<EPSNetworkRegistrationStatus> for RegistrationParams {
     fn from(v: EPSNetworkRegistrationStatus) -> Self {


### PR DESCRIPTION
Instead rely 100% on polling network registration status instead, until parsing of the URCs are correctly distinguished from the corresponding response