### PR TITLE
fix(*): only handle URCs in one place

### DIFF
--- a/ublox-cellular/src/services/data/mod.rs
+++ b/ublox-cellular/src/services/data/mod.rs
@@ -504,10 +504,6 @@ where
         Ok(self.network.send_internal(cmd, true)?)
     }
 
-    pub fn handle_urc<F: FnOnce(Urc) -> bool>(&mut self, f: F) -> Result<(), Error> {
-        self.network.at_tx.handle_urc(f).map_err(Error::Network)
-    }
-
     fn socket_ingress_all(&mut self) -> Result<(), Error> {
         if let Some(ref mut sockets) = self.sockets {
             let network = &mut self.network;


### PR DESCRIPTION
After the change to the new ATAT version, the URC handling can no longer be spread into multiple handlers, unless we do multiple URC subscribers. This PR changes the URC handling, to only occur in one place.

The downside of this PR is that we no longer handle URC's on every AT command we send. Not sure if this is going to be a problem.