### PR TITLE
fix: fixed async stm32 example due to progressed embassy main branch

### DIFF
--- a/examples/embassy-stm32-example/src/main.rs
+++ b/examples/embassy-stm32-example/src/main.rs
@@ -77,17 +77,17 @@ async fn main_task(spawner: Spawner) {
     let mut config = Config::default();
     {
         use embassy_stm32::rcc::*;
-        config.rcc.hsi = Some(Hsi::Mhz64);
+        config.rcc.hsi = Some(HSIPrescaler::DIV1);
         config.rcc.csi = true;
-        config.rcc.pll_src = PllSource::Hsi;
         config.rcc.pll1 = Some(Pll {
+            source: PllSource::HSI,
             prediv: PllPreDiv::DIV4,
             mul: PllMul::MUL50,
             divp: Some(PllDiv::DIV2),
             divq: Some(PllDiv::DIV8), // used by SPI3. 100Mhz.
             divr: None,
         });
-        config.rcc.sys = Sysclk::Pll1P; // 400 Mhz
+        config.rcc.sys = Sysclk::PLL1_P; // 400 Mhz
         config.rcc.ahb_pre = AHBPrescaler::DIV2; // 200 Mhz
         config.rcc.apb1_pre = APBPrescaler::DIV2; // 100 Mhz
         config.rcc.apb2_pre = APBPrescaler::DIV2; // 100 Mhz


### PR DESCRIPTION
Trying to build the the STM32 example failed. The reason is, that embassy's `main` branch has progressed.

Based on the crucial commit in embassy, the changes were made (but not tested).

https://github.com/embassy-rs/embassy/commit/a39ae12edcf23935df82d547fb2d997ca6b7c8d5


Sorry if this is unwanted, I am just wanted to try out this lib and came across this. So feel free to just reject it :). If it's just formally not correct, I am happy to follow the rules :).