### PR TITLE
Fix: State when losing connection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,10 @@
     ],
     "rust-analyzer.cargo.features": [
         "lara-r6",
-        "embassy-embedded-hal"
+        "embassy-embedded-hal",
+        "internal-network-stack"
     ],
-    "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
+    "rust-analyzer.cargo.target": "thumbv6m-none-eabi",
     "rust-analyzer.diagnostics.disabled": [
         "unresolved-import"
     ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ embassy-embedded-hal = { version = "0.3", optional = true }
 embedded-io-async = "0.6"
 
 [features]
-default = ["socket-udp", "socket-tcp", "ppp"]
+default = ["socket-udp", "socket-tcp"]
 
 
 ### Cellular feature list from ubxlib:

--- a/examples/embassy-rp2040-example/Cargo.toml
+++ b/examples/embassy-rp2040-example/Cargo.toml
@@ -4,28 +4,28 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-embassy-rp = { version = "0.1.0", features = [
+embassy-rp = { version = "0.4.0", features = [
     "defmt",
     "time-driver",
     "unstable-pac",
     "rom-v2-intrinsics",
     "critical-section-impl",
+    "rp2040",
 ] }
-embassy-executor = { version = "0.5.0", features = [
+embassy-executor = { version = "0.7.0", features = [
     "arch-cortex-m",
     "executor-thread",
     "defmt",
-    "integrated-timers",
     "nightly",
 ] }
-embassy-time = { version = "0.3", features = [
+embassy-time = { version = "0.4", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }
 embassy-futures = { version = "0.1", features = ["defmt"] }
 embassy-sync = { version = "0.6", features = ["defmt"] }
 
-embassy-net = { version = "0.4", features = [
+embassy-net = { version = "0.6", features = [
     "defmt",
     "packet-trace",
     "proto-ipv4",
@@ -34,10 +34,9 @@ embassy-net = { version = "0.4", features = [
     "udp",
     "dns",
 ] }
-embassy-net-ppp = { version = "0.1", features = ["defmt"] }
-embassy-at-cmux = { path = "../../../embassy/embassy-at-cmux", features = [
-    "defmt",
-] }
+embassy-net-ppp = { version = "0.2", features = ["defmt"] }
+
+embassy-at-cmux = { git = "https://github.com/MathiasKoch/embassy", rev = "66d78d425" }
 
 embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls", rev = "f788e02", default-features = false, features = [
     "defmt",
@@ -56,7 +55,7 @@ panic-probe = { version = "0.3.1", features = ["print-defmt"] }
 
 static_cell = { version = "2.0", features = [] }
 
-atat = { version = "0.23", features = ["derive", "bytes", "defmt"] }
+atat = { version = "0.24", features = ["derive", "bytes", "defmt"] }
 ublox-cellular-rs = { version = "0.4.0", path = "../..", features = [
     "lara-r6",
     "defmt",
@@ -65,7 +64,7 @@ reqwless = { git = "https://github.com/drogue-iot/reqwless", features = [
     "defmt",
 ] }
 smoltcp = { version = "*", default-features = false, features = [
-    "dns-max-server-count-4"
+    "dns-max-server-count-4",
 ] }
 rand_chacha = { version = "0.3", default-features = false }
 
@@ -87,14 +86,14 @@ no-std-net = { git = "https://github.com/rushmorem/no-std-net", branch = "issue-
 # embassy-futures = { git = "https://github.com/embassy-rs/embassy", branch = "main" }
 # embassy-executor = { git = "https://github.com/embassy-rs/embassy", branch = "main" }
 
-embassy-rp = { path = "../../../embassy/embassy-rp" }
-embassy-time = { path = "../../../embassy/embassy-time" }
-embassy-sync = { path = "../../../embassy/embassy-sync" }
-embassy-net = { path = "../../../embassy/embassy-net" }
-embassy-net-ppp = { path = "../../../embassy/embassy-net-ppp" }
-embassy-futures = { path = "../../../embassy/embassy-futures" }
-embassy-executor = { path = "../../../embassy/embassy-executor" }
-atat = { path = "../../../atat/atat" }
+# embassy-rp = { path = "../../../embassy/embassy-rp" }
+# embassy-time = { path = "../../../embassy/embassy-time" }
+# embassy-sync = { path = "../../../embassy/embassy-sync" }
+# embassy-net = { path = "../../../embassy/embassy-net" }
+# embassy-net-ppp = { path = "../../../embassy/embassy-net-ppp" }
+# embassy-futures = { path = "../../../embassy/embassy-futures" }
+# embassy-executor = { path = "../../../embassy/embassy-executor" }
+# atat = { path = "../../../atat/atat" }
 
 
 [profile.dev]

--- a/examples/embassy-rp2040-example/rust-toolchain.toml
+++ b/examples/embassy-rp2040-example/rust-toolchain.toml
@@ -1,8 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2024-02-01"
-components = [ "rust-src", "rustfmt", "llvm-tools" ]
-targets = [
-    "thumbv6m-none-eabi",
-]
+channel = "nightly-2025-02-01"
+components = ["rust-src", "rustfmt", "llvm-tools"]
+targets = ["thumbv6m-none-eabi"]

--- a/examples/embassy-rp2040-example/src/bin/embassy-internal-stack.rs
+++ b/examples/embassy-rp2040-example/src/bin/embassy-internal-stack.rs
@@ -1,7 +1,9 @@
 #![no_std]
 #![no_main]
+#![cfg(feature = "internal-network-stack")]
 #![allow(stable_features)]
 #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use defmt::*;
 use embassy_executor::Spawner;
@@ -10,13 +12,13 @@ use embassy_rp::gpio::Input;
 
 use embassy_rp::gpio::OutputOpenDrain;
 use embassy_rp::uart::BufferedUart;
-use embassy_rp::uart::BufferedUartRx;
-use embassy_rp::uart::BufferedUartTx;
 use embassy_rp::{bind_interrupts, peripherals::UART0, uart::BufferedInterruptHandler};
+use embassy_rp2040_example::cell_transport::CellTransport;
+
 use embassy_time::{Duration, Timer};
 use static_cell::StaticCell;
-use ublox_cellular::asynch::InternalRunner;
 use ublox_cellular::asynch::Resources;
+use ublox_cellular::asynch::Runner;
 use {defmt_rtt as _, panic_probe as _};
 
 use ublox_cellular::config::{Apn, CellularConfig};
@@ -86,18 +88,14 @@ async fn main(spawner: Spawner) {
         embassy_rp::uart::Config::default(),
     );
 
-    let (uart_rx, uart_tx) = cell_uart.split();
     let cell_nrst = gpio::OutputOpenDrain::new(p.PIN_4, gpio::Level::High);
     let cell_pwr = gpio::OutputOpenDrain::new(p.PIN_5, gpio::Level::High);
     let cell_vint = gpio::Input::new(p.PIN_6, gpio::Pull::None);
 
-    static RESOURCES: StaticCell<
-        Resources<BufferedUartTx<UART0>, CMD_BUF_SIZE, INGRESS_BUF_SIZE, URC_CAPACITY>,
-    > = StaticCell::new();
+    static RESOURCES: StaticCell<Resources<INGRESS_BUF_SIZE, URC_CAPACITY>> = StaticCell::new();
 
-    let (_net_device, mut control, runner) = ublox_cellular::asynch::new_internal(
-        uart_rx,
-        uart_tx,
+    let (runner, control) = ublox_cellular::asynch::Runner::new(
+        CellTransport(cell_uart),
         RESOURCES.init(Resources::new()),
         MyCelullarConfig {
             reset_pin: Some(cell_nrst),
@@ -119,9 +117,8 @@ async fn main(spawner: Spawner) {
 
     Timer::after(Duration::from_millis(1000)).await;
     loop {
-        control
-            .set_desired_state(OperationState::DataEstablished)
-            .await;
+        control.set_desired_state(OperationState::DataEstablished);
+
         info!("set_desired_state(PowerState::Alive)");
         while control.operation_state() != OperationState::DataEstablished {
             Timer::after(Duration::from_millis(1000)).await;
@@ -136,7 +133,7 @@ async fn main(spawner: Spawner) {
             info!("{}", signal_quality);
             if signal_quality.is_err() {
                 let desired_state = control.desired_state();
-                control.set_desired_state(desired_state).await
+                control.set_desired_state(desired_state);
             }
             if let Ok(sq) = signal_quality {
                 if let Ok(op) = operator {
@@ -158,7 +155,7 @@ async fn main(spawner: Spawner) {
             .await;
         info!("dns: {:?}", dns);
         Timer::after(Duration::from_millis(10000)).await;
-        control.set_desired_state(OperationState::PowerDown).await;
+        control.set_desired_state(OperationState::PowerDown);
         info!("set_desired_state(PowerState::PowerDown)");
         while control.operation_state() != OperationState::PowerDown {
             Timer::after(Duration::from_millis(1000)).await;
@@ -175,14 +172,7 @@ async fn main(spawner: Spawner) {
 
 #[embassy_executor::task]
 async fn cell_task(
-    mut runner: InternalRunner<
-        'static,
-        BufferedUartRx<'static, UART0>,
-        BufferedUartTx<'static, UART0>,
-        MyCelullarConfig,
-        INGRESS_BUF_SIZE,
-        URC_CAPACITY,
-    >,
+    mut runner: Runner<'static, CellTransport, MyCelullarConfig, INGRESS_BUF_SIZE, URC_CAPACITY>,
 ) -> ! {
     runner.run().await
 }

--- a/examples/embassy-rp2040-example/src/bin/embassy-smoltcp-ppp.rs
+++ b/examples/embassy-rp2040-example/src/bin/embassy-smoltcp-ppp.rs
@@ -1,7 +1,7 @@
-#![cfg(feature = "ppp")]
 #![no_std]
 #![no_main]
 #![allow(stable_features)]
+#![cfg(feature = "ppp")]
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 
@@ -15,9 +15,8 @@ use embassy_rp::gpio::Input;
 
 use embassy_rp::gpio::OutputOpenDrain;
 use embassy_rp::uart::BufferedUart;
-use embassy_rp::uart::BufferedUartRx;
-use embassy_rp::uart::BufferedUartTx;
 use embassy_rp::{bind_interrupts, peripherals::UART0, uart::BufferedInterruptHandler};
+use embassy_rp2040_example::cell_transport::CellTransport;
 use embassy_time::Duration;
 use embedded_tls::Aes128GcmSha256;
 use embedded_tls::TlsConfig;
@@ -32,6 +31,7 @@ use reqwless::request::RequestBuilder as _;
 use reqwless::response::Response;
 use static_cell::StaticCell;
 use ublox_cellular::asynch::Resources;
+use ublox_cellular::asynch::Runner;
 use {defmt_rtt as _, panic_probe as _};
 
 use ublox_cellular::config::{Apn, CellularConfig};
@@ -40,7 +40,6 @@ bind_interrupts!(struct Irqs {
     UART0_IRQ => BufferedInterruptHandler<UART0>;
 });
 
-const CMD_BUF_SIZE: usize = 128;
 const INGRESS_BUF_SIZE: usize = 512;
 const URC_CAPACITY: usize = 16;
 
@@ -111,10 +110,10 @@ async fn main(spawner: Spawner) {
     let cell_pwr = gpio::OutputOpenDrain::new(p.PIN_5, gpio::Level::High);
     let cell_vint = gpio::Input::new(p.PIN_6, gpio::Pull::None);
 
-    static RESOURCES: StaticCell<Resources<CMD_BUF_SIZE, INGRESS_BUF_SIZE, URC_CAPACITY>> =
-        StaticCell::new();
-    let mut runner = ublox_cellular::asynch::Runner::new(
-        cell_uart.split(),
+    static RESOURCES: StaticCell<Resources<INGRESS_BUF_SIZE, URC_CAPACITY>> = StaticCell::new();
+
+    let (mut cell_runner, control) = ublox_cellular::asynch::Runner::new(
+        CellTransport(cell_uart),
         RESOURCES.init(Resources::new()),
         MyCelullarConfig {
             reset_pin: Some(cell_nrst),
@@ -124,24 +123,27 @@ async fn main(spawner: Spawner) {
     );
 
     static PPP_STATE: StaticCell<embassy_net_ppp::State<2, 2>> = StaticCell::new();
-    let net_device = runner.ppp_stack(PPP_STATE.init(embassy_net_ppp::State::new()));
+    let net_device = cell_runner.ppp_stack(PPP_STATE.init(embassy_net_ppp::State::new()));
 
     // Generate random seed
     let seed = 0x0123_4567_89ab_cdef; // chosen by fair dice roll. guarenteed to be random.
 
     // Init network stack
-    static STACK: StaticCell<Stack<embassy_net_ppp::Device<'static>>> = StaticCell::new();
+    static STACK: StaticCell<Stack<'_>> = StaticCell::new();
     static STACK_RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
 
-    let stack = &*STACK.init(Stack::new(
+    let (stack, stack_runner) = embassy_net::new(
         net_device,
         embassy_net::Config::default(),
         STACK_RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
-    spawner.spawn(net_task(stack)).unwrap();
-    spawner.spawn(cell_task(runner, stack)).unwrap();
+    let stack = &*STACK.init(stack);
+
+    spawner.spawn(net_task(stack_runner)).unwrap();
+
+    spawner.spawn(cell_task_ppp(cell_runner, stack)).unwrap();
 
     stack.wait_config_up().await;
 
@@ -151,7 +153,9 @@ async fn main(spawner: Spawner) {
 
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
-    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+
+    let mut socket = TcpSocket::new(*stack, &mut rx_buffer, &mut tx_buffer);
+
     socket.set_timeout(Some(Duration::from_secs(20)));
 
     let hostname = "ecdsa-test.germancoding.com";
@@ -189,7 +193,7 @@ async fn main(spawner: Spawner) {
         .host(hostname)
         .content_type(ContentType::TextPlain)
         .build();
-    request.write(&mut tls).await.unwrap();
+    request.write_header(&mut tls).await.unwrap();
 
     let mut rx_buf = [0; 4096];
     let response = Response::read(&mut tls, reqwless::request::Method::GET, &mut rx_buf)
@@ -215,42 +219,22 @@ async fn main(spawner: Spawner) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<embassy_net_ppp::Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(
+    mut stack_runner: embassy_net::Runner<'static, embassy_net_ppp::Device<'static>>,
+) -> ! {
+    stack_runner.run().await
 }
 
 #[embassy_executor::task]
-async fn cell_task(
-    runner: ublox_cellular::asynch::Runner<
+async fn cell_task_ppp(
+    mut ppp_runner: Runner<
         'static,
-        BufferedUartRx<'static, UART0>,
-        BufferedUartTx<'static, UART0>,
+        CellTransport,
         MyCelullarConfig,
         INGRESS_BUF_SIZE,
         URC_CAPACITY,
     >,
-    stack: &'static embassy_net::Stack<embassy_net_ppp::Device<'static>>,
+    stack: &'static embassy_net::Stack<'static>,
 ) -> ! {
-    runner
-        .run(|ipv4| {
-            let Some(addr) = ipv4.address else {
-                defmt::warn!("PPP did not provide an IP address.");
-                return;
-            };
-            let mut dns_servers = heapless::Vec::new();
-            for s in ipv4.dns_servers.iter().flatten() {
-                let _ = dns_servers.push(embassy_net::Ipv4Address::from_bytes(&s.0));
-            }
-            let config = embassy_net::ConfigV4::Static(embassy_net::StaticConfigV4 {
-                address: embassy_net::Ipv4Cidr::new(
-                    embassy_net::Ipv4Address::from_bytes(&addr.0),
-                    0,
-                ),
-                gateway: None,
-                dns_servers,
-            });
-
-            stack.set_config_v4(config);
-        })
-        .await
+    ppp_runner.run(*stack).await
 }

--- a/examples/embassy-rp2040-example/src/cell_transport.rs
+++ b/examples/embassy-rp2040-example/src/cell_transport.rs
@@ -1,0 +1,43 @@
+use core::result::Result;
+use embassy_rp::{peripherals::UART0, uart::BufferedUart};
+pub struct CellTransport(pub BufferedUart<'static, UART0>);
+
+impl ublox_cellular::config::Transport for CellTransport {
+    fn set_baudrate(&mut self, baudrate: u32) {
+        self.0.set_baudrate(baudrate)
+    }
+
+    fn split_ref(
+        &mut self,
+    ) -> (
+        impl embedded_io_async::Write,
+        impl embedded_io_async::Read + embedded_io_async::BufRead,
+    ) {
+        self.0.split_ref()
+    }
+}
+impl embedded_io_async::ErrorType for CellTransport {
+    type Error = embassy_rp::uart::Error;
+}
+
+impl embedded_io_async::Read for CellTransport {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.0.read(buf).await
+    }
+}
+
+impl embedded_io_async::BufRead for CellTransport {
+    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        self.0.fill_buf().await
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.0.consume(amt)
+    }
+}
+
+impl embedded_io_async::Write for CellTransport {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.0.write(buf).await
+    }
+}

--- a/examples/embassy-rp2040-example/src/lib.rs
+++ b/examples/embassy-rp2040-example/src/lib.rs
@@ -1,0 +1,2 @@
+#![cfg_attr(not(test), no_std)]
+pub mod cell_transport;

--- a/examples/tokio-std-example/src/bin/embassy-internal-stack.rs
+++ b/examples/tokio-std-example/src/bin/embassy-internal-stack.rs
@@ -15,7 +15,6 @@ use embassy_rp::uart::BufferedUartTx;
 use embassy_rp::{bind_interrupts, peripherals::UART0, uart::BufferedInterruptHandler};
 use embassy_time::{Duration, Timer};
 use static_cell::StaticCell;
-use ublox_cellular::asynch::InternalRunner;
 use ublox_cellular::asynch::Resources;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -95,7 +94,7 @@ async fn main(spawner: Spawner) {
         Resources<BufferedUartTx<UART0>, CMD_BUF_SIZE, INGRESS_BUF_SIZE, URC_CAPACITY>,
     > = StaticCell::new();
 
-    let (_net_device, mut control, runner) = ublox_cellular::asynch::new_internal(
+    let (_net_device, mut control, runner) = ublox_cellular::asynch::new(
         uart_rx,
         uart_tx,
         RESOURCES.init(Resources::new()),
@@ -175,7 +174,7 @@ async fn main(spawner: Spawner) {
 
 #[embassy_executor::task]
 async fn cell_task(
-    mut runner: InternalRunner<
+    mut runner: Runner<
         'static,
         BufferedUartRx<'static, UART0>,
         BufferedUartTx<'static, UART0>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80"
+channel = "1.83"
 components = ["rust-src", "rustfmt", "llvm-tools", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "thumbv7em-none-eabihf"]

--- a/src/asynch/runner.rs
+++ b/src/asynch/runner.rs
@@ -198,7 +198,6 @@ where
         // let data_channel = self.data_channel;
         state::Device {
             shared: &self.ch.shared,
-            desired_state_pub_sub: &self.ch.desired_state_pub_sub,
             urc_subscription: self.urc_channel.subscribe().unwrap(),
         }
     }
@@ -497,7 +496,7 @@ where
         Ok(())
     }
 
-    pub async fn run(&mut self, stack: embassy_net::Stack<'_>) -> ! {
+    pub async fn run(&mut self, #[cfg(feature = "ppp")] stack: embassy_net::Stack<'_>) -> ! {
         loop {
             let _ = PwrCtrl::new(&self.ch, &mut self.config).power_down().await;
 

--- a/src/asynch/runner.rs
+++ b/src/asynch/runner.rs
@@ -1,4 +1,4 @@
-use core::{future::poll_fn, task::Poll};
+use core::{default, future::poll_fn, task::Poll};
 
 use crate::{
     asynch::{network::NetDevice, state::OperationState},
@@ -13,8 +13,9 @@ use crate::{
         device_lock::{responses::PinStatus, types::PinStatusCode, GetPinStatus},
         general::{responses::FirmwareVersion, GetCCID, GetFirmwareVersion, GetModelId},
         ip_transport_layer::{
+            responses::CreateSocketResponse,
             types::{AoNState, PreferredProtocolType, SocketProtocol},
-            CreateSocket,
+            CloseSocket, CreateSocket,
         },
         ipc::SetMultiplexing,
         mobile_control::{
@@ -48,7 +49,7 @@ use atat::{
 
 use embassy_futures::{
     join::join,
-    select::{select3, Either3},
+    select::{select, select3, Either3},
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use embassy_time::{with_timeout, Duration, Instant, Timer};
@@ -513,16 +514,17 @@ where
 
             #[cfg(feature = "ppp")]
             let ppp_fut = async {
-                self.ch
-                    .wait_for_operation_state(OperationState::DataEstablished)
-                    .await;
-
-                Timer::after_secs(1).await;
-
                 let mut fails = 0;
                 let mut last_start = None;
 
+                #[cfg(feature = "lara-r6")]
+                let mut open_socket_id: Option<u8> = None;
+
                 loop {
+                    self.ch
+                        .wait_for_operation_state(OperationState::DataEstablished)
+                        .await;
+
                     if let Some(last_start) = last_start {
                         Timer::at(last_start + Duration::from_secs(10)).await;
                         // Do not attempt to start too fast.
@@ -555,15 +557,22 @@ where
                         //This is needed as a workaround for lara r6 firmware 0.13.
                         // Documentation for workaround: https://content.u-blox.com/sites/default/files/documents/LARA-R6001D-00B-IP_IN_UBX-22008409.pdf
                         // In section B.1.2 Dial-up
-                        let _ = at_client
-                            .send(&CreateSocket {
-                                protocol: SocketProtocol::UDP,
-                                local_port: Some(1),
-                                preferred_protocol_type: Some(PreferredProtocolType::Ipv4),
-                                cid: Some(1),
-                                report_aon: None,
-                            })
-                            .await;
+                        {
+                            let res = at_client
+                                .send(&CreateSocket {
+                                    protocol: SocketProtocol::UDP,
+                                    local_port: Some(1),
+                                    preferred_protocol_type: Some(PreferredProtocolType::Ipv4),
+                                    cid: Some(1),
+                                    report_aon: None,
+                                })
+                                .await;
+
+                            if let Ok(socket_id) = res {
+                                open_socket_id = Some(socket_id.socket);
+                                info!("Socket opened");
+                            }
+                        }
 
                         // Send AT command to enter PPP mode
                         let res = at_client.send(&EnterPPP { cid: C::CONTEXT_ID }).await;
@@ -578,6 +587,19 @@ where
 
                     // Check for CTS low (bit 2)
                     self.data_channel.set_hangup_detection(0x04, 0x00);
+
+                    // If we exit ppp_runner or ppp_fut is dropped we need to set the 3 state to
+                    // trigger correct behavior
+                    let ondrop = OnDrop::new(|| {
+                        // Set stack to None might not be needed, but it will just be set again
+                        // when we get a new connection
+                        stack.set_config_v4(embassy_net::ConfigV4::None);
+                        self.ch.set_link_state(state::LinkState::Down);
+                        // Setting desired state will trigger cell_device runner to run to desired state
+                        // If this is not changed when we lose connection it will
+                        // skip the wait_for_operation_state dataestablished
+                        self.ch.set_desired_state(OperationState::Initialized);
+                    });
 
                     info!("RUNNING PPP");
                     let res = self
@@ -607,18 +629,32 @@ where
                         .await;
 
                     info!("ppp failed: {:?}", res);
-                    self.ch.set_link_state(state::LinkState::Down);
+
+                    drop(ondrop);
                     self.data_channel.clear_hangup_detection();
 
-                    // escape back to data mode.
-                    self.data_channel
-                        .set_lines(embassy_at_cmux::Control::from_bits(0x44 << 1), None);
-                    Timer::after(Duration::from_millis(100)).await;
-                    self.data_channel
-                        .set_lines(embassy_at_cmux::Control::from_bits(0x46 << 1), None);
+                    // Must be large enough to hold CreateSocket cmd
+                    let mut buf = [0u8; 25];
 
-                    if self.ch.desired_state(None) != OperationState::DataEstablished {
-                        break;
+                    let mut at_client = SimpleClient::new(
+                        &mut self.data_channel,
+                        atat::AtDigester::<Urc>::new(),
+                        &mut buf,
+                        C::AT_CONFIG,
+                    );
+                    // Send AT command to exit PPP mode
+                    let _ = at_client
+                        .send(&heapless::String::<5>::try_from("+++\r\n").unwrap())
+                        .await;
+
+                    // Must be large enough to hold CreateSocket cmd
+                    #[cfg(feature = "lara-r6")]
+                    if let Some(socket_id) = open_socket_id {
+                        at_client
+                            .send(&CloseSocket { socket: socket_id })
+                            .await
+                            .ok();
+                        open_socket_id = None;
                     }
                 }
             };
@@ -719,5 +755,27 @@ where
                 }
             }
         }
+    }
+}
+
+struct OnDrop<F: FnOnce()> {
+    f: core::mem::MaybeUninit<F>,
+}
+
+impl<F: FnOnce()> OnDrop<F> {
+    fn new(f: F) -> Self {
+        Self {
+            f: core::mem::MaybeUninit::new(f),
+        }
+    }
+
+    fn defuse(self) {
+        core::mem::forget(self)
+    }
+}
+
+impl<F: FnOnce()> Drop for OnDrop<F> {
+    fn drop(&mut self) {
+        unsafe { self.f.as_ptr().read()() }
     }
 }

--- a/src/asynch/state.rs
+++ b/src/asynch/state.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::command::Urc;
 use core::cell::RefCell;
 use core::future::poll_fn;
 use core::task::{Context, Poll};
@@ -258,7 +259,7 @@ impl<'d> Runner<'d> {
 pub struct Device<'d, const URC_CAPACITY: usize> {
     pub(crate) shared: &'d Mutex<NoopRawMutex, RefCell<Shared>>,
     // pub(crate) at: AtHandle<'d, AT>,
-    pub(crate) urc_subscription: UrcSubscription<'d, Urc, URC_CAPACITY, 2>,
+    pub(crate) urc_subscription: atat::UrcSubscription<'d, Urc, URC_CAPACITY, 2>,
 }
 
 #[cfg(feature = "internal-network-stack")]
@@ -275,20 +276,6 @@ impl<'d, const URC_CAPACITY: usize> Device<'d, URC_CAPACITY> {
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
             s.state_waker.register(cx.waker());
-            s.operation_state
-        })
-    }
-
-    pub fn link_state(&self) -> LinkState {
-        self.shared.lock(|s| {
-            let s = &mut *s.borrow_mut();
-            s.link_state
-        })
-    }
-
-    pub fn operation_state(&self) -> OperationState {
-        self.shared.lock(|s| {
-            let s = &mut *s.borrow_mut();
             s.operation_state
         })
     }
@@ -320,11 +307,12 @@ impl<'d, const URC_CAPACITY: usize> Device<'d, URC_CAPACITY> {
     }
 
     pub async fn wait_for_desired_state_change(&self) -> OperationState {
-        let current_desired = self.shared.lock(|s| s.borrow().desired_state);
+        let old_desired = self.shared.lock(|s| s.borrow().desired_state);
 
         poll_fn(|cx| {
-            if self.desired_state(cx) != current_desired {
-                return Poll::Ready(ps);
+            let current_desired = self.desired_state(cx);
+            if current_desired != old_desired {
+                return Poll::Ready(current_desired);
             }
             Poll::Pending
         })

--- a/src/command/ip_transport_layer/mod.rs
+++ b/src/command/ip_transport_layer/mod.rs
@@ -6,6 +6,10 @@ use super::NoResponse;
 use atat::atat_derive::AtatCmd;
 #[cfg(feature = "internal-network-stack")]
 pub use internal_network_stack::*;
+
+#[cfg(feature = "internal-network-stack")]
+pub use internal_network_stack::urc;
+
 use responses::CreateSocketResponse;
 use types::{AoNState, PreferredProtocolType, SocketProtocol};
 
@@ -43,8 +47,7 @@ pub struct CloseSocket {
 
 #[cfg(feature = "internal-network-stack")]
 mod internal_network_stack {
-    #[path = "../urc.rs"]
-    pub mod urc;
+    use super::urc;
 
     use super::responses::{
         CreateSocketResponse, SocketControlResponse, SocketData, SocketErrorResponse,

--- a/src/command/ip_transport_layer/mod.rs
+++ b/src/command/ip_transport_layer/mod.rs
@@ -4,6 +4,8 @@ pub mod responses;
 pub mod types;
 use super::NoResponse;
 use atat::atat_derive::AtatCmd;
+#[cfg(feature = "internal-network-stack")]
+pub use internal_network_stack::*;
 use responses::CreateSocketResponse;
 use types::{AoNState, PreferredProtocolType, SocketProtocol};
 
@@ -33,32 +35,26 @@ pub struct CreateSocket {
 }
 
 #[derive(Clone, AtatCmd)]
-#[cfg_attr(
-    not(feature = "internal-network-stack"),
-    at_cmd("+USOCL", NoResponse, attempts = 1, timeout_ms = 120000)
-)]
+#[at_cmd("+USOCL", NoResponse, attempts = 1, timeout_ms = 120000)]
 pub struct CloseSocket {
     #[at_arg(position = 0)]
     pub socket: u8,
 }
 
 #[cfg(feature = "internal-network-stack")]
-pub use internal_network_stack::*;
-#[cfg(feature = "internal-network-stack")]
 mod internal_network_stack {
-
     #[path = "../urc.rs"]
     pub mod urc;
 
+    use super::responses::{
+        CreateSocketResponse, SocketControlResponse, SocketData, SocketErrorResponse,
+        UDPSendToDataResponse, UDPSocketData, WriteSocketDataResponse,
+    };
     use super::types::{
         HexMode, PreferredProtocolType, SocketControlParam, SocketProtocol, SslTlsStatus,
     };
     use atat::atat_derive::AtatCmd;
     use core::net::IpAddr;
-    use responses::{
-        CreateSocketResponse, SocketControlResponse, SocketData, SocketErrorResponse,
-        UDPSendToDataResponse, UDPSocketData, WriteSocketDataResponse,
-    };
 
     use super::NoResponse;
     use ublox_sockets::SocketHandle;

--- a/src/command/ip_transport_layer/mod.rs
+++ b/src/command/ip_transport_layer/mod.rs
@@ -1,8 +1,10 @@
 //! ### 25 - Internet protocol transport layer Commands
 //!
+pub mod responses;
 pub mod types;
 use super::NoResponse;
 use atat::atat_derive::AtatCmd;
+use responses::CreateSocketResponse;
 use types::{AoNState, PreferredProtocolType, SocketProtocol};
 
 /// 25.3 Create Socket +USOCR
@@ -16,11 +18,7 @@ use types::{AoNState, PreferredProtocolType, SocketProtocol};
 /// It is possible to specify the local port to bind within the socket in order to send data from a specific port. The
 /// bind functionality is supported for both TCP and UDP sockets.
 #[derive(Clone, AtatCmd)]
-#[cfg_attr(
-    feature = "internal-network-stack",
-    at_cmd("+USOCR", CreateSocketResponse)
-)]
-#[cfg_attr(not(feature = "internal-network-stack"), at_cmd("+USOCR", NoResponse))]
+#[at_cmd("+USOCR", CreateSocketResponse)]
 pub struct CreateSocket {
     #[at_arg(position = 0)]
     pub protocol: SocketProtocol,
@@ -34,12 +32,21 @@ pub struct CreateSocket {
     pub report_aon: Option<AoNState>,
 }
 
+#[derive(Clone, AtatCmd)]
+#[cfg_attr(
+    not(feature = "internal-network-stack"),
+    at_cmd("+USOCL", NoResponse, attempts = 1, timeout_ms = 120000)
+)]
+pub struct CloseSocket {
+    #[at_arg(position = 0)]
+    pub socket: u8,
+}
+
 #[cfg(feature = "internal-network-stack")]
 pub use internal_network_stack::*;
 #[cfg(feature = "internal-network-stack")]
 mod internal_network_stack {
-    #[path = "../responses.rs"]
-    pub mod responses;
+
     #[path = "../urc.rs"]
     pub mod urc;
 

--- a/src/command/ip_transport_layer/responses.rs
+++ b/src/command/ip_transport_layer/responses.rs
@@ -13,8 +13,7 @@ pub struct CreateSocketResponse {
 pub use internal_network_stack_respones::*;
 #[cfg(feature = "internal-network-stack")]
 pub mod internal_network_stack_respones {
-    use super::types::{SocketControlParam, SocketProtocol};
-    use crate::command::ip_transport_layer::types::AoNState;
+    use crate::command::ip_transport_layer::types::{AoNState, SocketControlParam, SocketProtocol};
     use atat::atat_derive::AtatResp;
     use core::net::IpAddr;
     use heapless::String;

--- a/src/command/ip_transport_layer/responses.rs
+++ b/src/command/ip_transport_layer/responses.rs
@@ -1,85 +1,109 @@
 //! Responses for Internet protocol transport layer Commands
-use crate::command::ip_transport_layer::types::AoNState;
 
-use super::types::{SocketControlParam, SocketProtocol};
 use atat::atat_derive::AtatResp;
-use core::net::IpAddr;
-use heapless::String;
-use ublox_sockets::SocketHandle;
 
-pub const INGRESS_CHUNK_SIZE: usize = 256;
-
-/// 25.3 Create Socket +USOCR
+#[cfg(not(feature = "internal-network-stack"))]
 #[derive(Debug, Clone, AtatResp)]
 pub struct CreateSocketResponse {
     #[at_arg(position = 0)]
-    pub socket: SocketHandle,
-    #[at_arg(position = 1)]
-    pub protocol: SocketProtocol,
-    #[at_arg(position = 2)]
-    pub aon_state: AoNState,
+    pub socket: u8,
 }
 
-/// 25.8 Get Socket Error +USOER
-#[derive(Clone, AtatResp)]
-pub struct SocketErrorResponse {
-    #[at_arg(position = 0)]
-    pub error: u8,
-}
+#[cfg(feature = "internal-network-stack")]
+pub use internal_network_stack_respones::*;
+#[cfg(feature = "internal-network-stack")]
+pub mod internal_network_stack_respones {
+    use super::types::{SocketControlParam, SocketProtocol};
+    use crate::command::ip_transport_layer::types::AoNState;
+    use atat::atat_derive::AtatResp;
+    use core::net::IpAddr;
+    use heapless::String;
+    use ublox_sockets::SocketHandle;
 
-/// 25.10 Write socket data +USOWR
-#[derive(Clone, AtatResp)]
-pub struct WriteSocketDataResponse {
-    #[at_arg(position = 0)]
-    pub socket: SocketHandle,
-    #[at_arg(position = 1)]
-    pub length: usize,
-}
+    pub const INGRESS_CHUNK_SIZE: usize = 256;
 
-/// 25.11 UDP Send To data +USOST:
-#[derive(Clone, AtatResp)]
-pub struct UDPSendToDataResponse {
-    #[at_arg(position = 0)]
-    pub socket: SocketHandle,
-    #[at_arg(position = 1)]
-    pub length: usize,
-}
+    /// 25.3 Create Socket +USOCR
+    #[derive(Debug, Clone, AtatResp)]
+    pub struct CreateSocketResponse {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub protocol: SocketProtocol,
+        #[at_arg(position = 2)]
+        pub aon_state: AoNState,
+    }
 
-/// 25.12 Read Socket Data +USORD
-#[derive(Clone, AtatResp)]
-pub struct SocketData {
-    #[at_arg(position = 0)]
-    pub socket: SocketHandle,
-    #[at_arg(position = 1)]
-    pub length: usize,
-    #[at_arg(position = 2)]
-    // Note: Data max length is `INGRESS_CHUNK_SIZE` * 2, due to hex encoding
-    pub data: Option<String<{ INGRESS_CHUNK_SIZE * 2 }>>,
-}
+    #[derive(Debug, Clone, AtatResp)]
+    pub struct CloseSocketResponse {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub protocol: SocketProtocol,
+        #[at_arg(position = 2)]
+        pub aon_state: AoNState,
+    }
 
-/// 25.13 Read UDP Socket Data +USORF
-#[derive(Clone, AtatResp)]
-pub struct UDPSocketData {
-    #[at_arg(position = 0)]
-    pub socket: SocketHandle,
-    #[at_arg(position = 1)]
-    pub remote_addr: IpAddr,
-    #[at_arg(position = 2)]
-    pub remote_port: u16,
-    #[at_arg(position = 3)]
-    pub length: usize,
-    #[at_arg(position = 4)]
-    // Note: Data max length is `INGRESS_CHUNK_SIZE` * 2, due to hex encoding
-    pub data: Option<String<{ INGRESS_CHUNK_SIZE * 2 }>>,
-}
+    /// 25.8 Get Socket Error +USOER
+    #[derive(Clone, AtatResp)]
+    pub struct SocketErrorResponse {
+        #[at_arg(position = 0)]
+        pub error: u8,
+    }
 
-/// 25.25 Socket control +USOCTL
-#[derive(Clone, AtatResp)]
-pub struct SocketControlResponse {
-    #[at_arg(position = 0)]
-    pub socket: SocketHandle,
-    #[at_arg(position = 1)]
-    pub param_id: SocketControlParam,
-    #[at_arg(position = 2)]
-    pub param_val: u32,
+    /// 25.10 Write socket data +USOWR
+    #[derive(Clone, AtatResp)]
+    pub struct WriteSocketDataResponse {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub length: usize,
+    }
+
+    /// 25.11 UDP Send To data +USOST:
+    #[derive(Clone, AtatResp)]
+    pub struct UDPSendToDataResponse {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub length: usize,
+    }
+
+    /// 25.12 Read Socket Data +USORD
+    #[derive(Clone, AtatResp)]
+    pub struct SocketData {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub length: usize,
+        #[at_arg(position = 2)]
+        // Note: Data max length is `INGRESS_CHUNK_SIZE` * 2, due to hex encoding
+        pub data: Option<String<{ INGRESS_CHUNK_SIZE * 2 }>>,
+    }
+
+    /// 25.13 Read UDP Socket Data +USORF
+    #[derive(Clone, AtatResp)]
+    pub struct UDPSocketData {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub remote_addr: IpAddr,
+        #[at_arg(position = 2)]
+        pub remote_port: u16,
+        #[at_arg(position = 3)]
+        pub length: usize,
+        #[at_arg(position = 4)]
+        // Note: Data max length is `INGRESS_CHUNK_SIZE` * 2, due to hex encoding
+        pub data: Option<String<{ INGRESS_CHUNK_SIZE * 2 }>>,
+    }
+
+    /// 25.25 Socket control +USOCTL
+    #[derive(Clone, AtatResp)]
+    pub struct SocketControlResponse {
+        #[at_arg(position = 0)]
+        pub socket: SocketHandle,
+        #[at_arg(position = 1)]
+        pub param_id: SocketControlParam,
+        #[at_arg(position = 2)]
+        pub param_val: u32,
+    }
 }

--- a/src/command/ip_transport_layer/types.rs
+++ b/src/command/ip_transport_layer/types.rs
@@ -57,7 +57,7 @@ pub enum PreferredProtocolType {
     Ipv6 = 1,
 }
 
-#[derive(Clone, PartialEq, Eq, AtatEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, AtatEnum)]
 pub enum AoNState {
     DoNotReport = 0,
     Report = 1,


### PR DESCRIPTION
When testing our firmware I ran into many times that when losing connection the ppp_run loop skips the "wait_operation_state(DataEstablished)" because the operation state never got changed when we lost connection. 
The cell_device in device_fut is waiting for registration to change but when I tested it the ppp_run looped around before the device got the registration change. 

I fixed this by setting desired state to initialized once we exit the embassy-net-ppp run. 
I also added a drop implementation for this, as in cases where the select breaks we still wants to set the states. 