### PR TITLE
deps: Update embassy, atat, heapless and related dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,17 @@ name = "ublox_cellular"
 doctest = false
 
 [dependencies]
-atat = { version = "0.24", features = ["derive", "bytes"] }
-heapless = { version = "^0.8", features = ["serde"] }
+# atat = { version = "0.24", features = ["derive", "bytes"] }
+atat = { git = "ssh://git@github.com/FactbirdHQ/atat", rev = "b817747", features = [
+    "derive",
+    "bytes",
+] }
+heapless = { version = "0.9", features = ["serde"] }
 serde = { version = "^1", default-features = false, features = ["derive"] }
-ublox-sockets = { git = "https://github.com/FactbirdHQ/ublox-sockets", rev = "0b0d186", optional = true }
-embassy-time = "0.4"
-embassy-sync = "0.6"
+ublox-sockets = { git = "https://github.com/FactbirdHQ/ublox-sockets", rev = "5e252b8", optional = true }
+embassy-time = "0.5.0"
+
+embassy-sync = "0.7.2"
 
 log = { version = "^0.4", default-features = false, optional = true }
 defmt = { version = "^0.3", optional = true }
@@ -32,14 +37,14 @@ embassy-futures = { version = "0.1" }
 embedded-hal = "1.0.0"
 embedded-nal-async = { version = "0.8" }
 
-embassy-at-cmux = { git = "https://github.com/MathiasKoch/embassy", rev = "66d78d425" }
+embassy-at-cmux = { git = "https://github.com/MathiasKoch/embassy", rev = "e438b00" }
 
-embassy-net-ppp = { version = "0.2", optional = true }
-embassy-net = { version = "0.6", features = [
+embassy-net-ppp = { version = "0.2.1", optional = true }
+embassy-net = { version = "0.7.1", features = [
     "proto-ipv4",
     "medium-ip",
 ], optional = true }
-embassy-embedded-hal = { version = "0.3", optional = true }
+embassy-embedded-hal = { version = "0.5.0", optional = true }
 
 embedded-io-async = "0.6"
 
@@ -100,7 +105,7 @@ socket-udp = ["ublox-sockets?/socket-udp", "embassy-net?/udp"]
 defmt = [
     "dep:defmt",
     "atat/defmt",
-    "heapless/defmt-03",
+    "heapless/defmt",
     "embassy-time/defmt",
     "embassy-sync/defmt",
     "embassy-at-cmux/defmt",
@@ -130,14 +135,11 @@ sara-u201 = [
 ]
 toby-r2 = []
 
+
 [workspace]
 members = []
 default-members = ["."]
 exclude = ["examples"]
-
-# [patch.crates-io]
-# atat = { git = "https://github.com/FactbirdHQ/atat", rev = "2f55331" }
-# atat = { path = "../atat/atat" }
-
-# [patch."https://github.com/MathiasKoch/embassy"]
-# embassy-at-cmux = { path = "../embassy/embassy-at-cmux" }
+[patch.crates-io]
+embassy-time ={ git = "https://github.com/MathiasKoch/embassy", rev = "e438b00"}
+embassy-net ={ git = "https://github.com/MathiasKoch/embassy", rev = "e438b00"}

--- a/examples/embassy-rp2040-example/Cargo.toml
+++ b/examples/embassy-rp2040-example/Cargo.toml
@@ -43,7 +43,7 @@ embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls", rev = "f788
 ] }
 
 embedded-io-async = { version = "0.6" }
-heapless = "0.8"
+heapless = "0.9"
 portable-atomic = { version = "1.5.1", features = ["critical-section"] }
 
 cortex-m = { version = "0.7.7", features = ["inline-asm"] }

--- a/examples/tokio-std-example/Cargo.toml
+++ b/examples/tokio-std-example/Cargo.toml
@@ -31,7 +31,7 @@ embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls", rev = "f788
 
 embedded-io-adapters = { version = "0.6", features = ["tokio-1"] }
 embedded-io-async = { version = "0.6" }
-heapless = "0.8"
+heapless = "0.9"
 
 env_logger = "0.11"
 log = "0.4.21"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.90"
 components = ["rust-src", "rustfmt", "llvm-tools", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
## Summary
- Update embassy stack to newer versions (time 0.5.0, sync 0.7.2, net 0.7.1, ppp 0.2.1)
- Update embassy-at-cmux to rev e438b00
- Switch atat to git dependency from FactbirdHQ (rev b817747)
- Update heapless from ^0.8 to 0.9
- Update ublox-sockets to rev 5e252b8
- Add crates-io patches for embassy-time and embassy-net

## Test plan
- [ ] `cargo build --all-features` passes
- [ ] Examples build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)