### PR TITLE
fix: Transport flush, state management, and network improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,17 @@ name = "ublox_cellular"
 doctest = false
 
 [dependencies]
-atat = { version = "0.24", features = ["derive", "bytes"] }
-heapless = { version = "^0.8", features = ["serde"] }
+# atat = { version = "0.24", features = ["derive", "bytes"] }
+atat = { git = "ssh://git@github.com/FactbirdHQ/atat", rev = "b817747", features = [
+    "derive",
+    "bytes",
+] }
+heapless = { version = "0.9", features = ["serde"] }
 serde = { version = "^1", default-features = false, features = ["derive"] }
-ublox-sockets = { git = "https://github.com/FactbirdHQ/ublox-sockets", rev = "0b0d186", optional = true }
-embassy-time = "0.4"
-embassy-sync = "0.6"
+ublox-sockets = { git = "https://github.com/FactbirdHQ/ublox-sockets", rev = "5e252b8", optional = true }
+embassy-time = "0.5.0"
+
+embassy-sync = "0.7.2"
 
 log = { version = "^0.4", default-features = false, optional = true }
 defmt = { version = "^0.3", optional = true }
@@ -32,14 +37,14 @@ embassy-futures = { version = "0.1" }
 embedded-hal = "1.0.0"
 embedded-nal-async = { version = "0.8" }
 
-embassy-at-cmux = { git = "https://github.com/MathiasKoch/embassy", rev = "66d78d425" }
+embassy-at-cmux = { git = "https://github.com/MathiasKoch/embassy", rev = "e438b00" }
 
-embassy-net-ppp = { version = "0.2", optional = true }
-embassy-net = { version = "0.6", features = [
+embassy-net-ppp = { version = "0.2.1", optional = true }
+embassy-net = { version = "0.7.1", features = [
     "proto-ipv4",
     "medium-ip",
 ], optional = true }
-embassy-embedded-hal = { version = "0.3", optional = true }
+embassy-embedded-hal = { version = "0.5.0", optional = true }
 
 embedded-io-async = "0.6"
 
@@ -100,7 +105,7 @@ socket-udp = ["ublox-sockets?/socket-udp", "embassy-net?/udp"]
 defmt = [
     "dep:defmt",
     "atat/defmt",
-    "heapless/defmt-03",
+    "heapless/defmt",
     "embassy-time/defmt",
     "embassy-sync/defmt",
     "embassy-at-cmux/defmt",
@@ -130,14 +135,11 @@ sara-u201 = [
 ]
 toby-r2 = []
 
+
 [workspace]
 members = []
 default-members = ["."]
 exclude = ["examples"]
-
-# [patch.crates-io]
-# atat = { git = "https://github.com/FactbirdHQ/atat", rev = "2f55331" }
-# atat = { path = "../atat/atat" }
-
-# [patch."https://github.com/MathiasKoch/embassy"]
-# embassy-at-cmux = { path = "../embassy/embassy-at-cmux" }
+[patch.crates-io]
+embassy-time ={ git = "https://github.com/MathiasKoch/embassy", rev = "e438b00"}
+embassy-net ={ git = "https://github.com/MathiasKoch/embassy", rev = "e438b00"}

--- a/examples/embassy-rp2040-example/Cargo.toml
+++ b/examples/embassy-rp2040-example/Cargo.toml
@@ -43,7 +43,7 @@ embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls", rev = "f788
 ] }
 
 embedded-io-async = { version = "0.6" }
-heapless = "0.8"
+heapless = "0.9"
 portable-atomic = { version = "1.5.1", features = ["critical-section"] }
 
 cortex-m = { version = "0.7.7", features = ["inline-asm"] }

--- a/examples/tokio-std-example/Cargo.toml
+++ b/examples/tokio-std-example/Cargo.toml
@@ -31,7 +31,7 @@ embedded-tls = { git = "https://github.com/drogue-iot/embedded-tls", rev = "f788
 
 embedded-io-adapters = { version = "0.6", features = ["tokio-1"] }
 embedded-io-async = { version = "0.6" }
-heapless = "0.8"
+heapless = "0.9"
 
 env_logger = "0.11"
 log = "0.4.21"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.90"
 components = ["rust-src", "rustfmt", "llvm-tools", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "thumbv7em-none-eabihf"]

--- a/src/asynch/control.rs
+++ b/src/asynch/control.rs
@@ -1,18 +1,21 @@
 use core::cell::Cell;
 
 use atat::{asynch::AtatClient, response_slot::ResponseSlotGuard};
-use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Sender};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Sender, mutex::Mutex};
 use embassy_time::{with_timeout, Duration, Timer};
 
 use crate::{
     command::{
-        general::{types::FirmwareVersion, GetFirmwareVersion},
-        gpio::{types::GpioMode, SetGpioConfiguration},
+        general::{types::FirmwareVersion, GetCCID, GetFirmwareVersion},
+        gpio::{types::GpioMode, ReadGpioPin, SetGpioConfiguration},
         network_service::{
             responses::{OperatorSelection, SignalQuality},
+            types::RatAct,
             GetOperatorSelection, GetSignalQuality,
         },
+        psn::GetPDPContextDefinition,
     },
+    config::Apn,
     error::Error,
 };
 
@@ -22,7 +25,8 @@ use super::{
 };
 
 pub(crate) struct ProxyClient<'a, const INGRESS_BUF_SIZE: usize> {
-    pub(crate) req_sender: Sender<'a, NoopRawMutex, heapless::Vec<u8, MAX_CMD_LEN>, 1>,
+    pub(crate) req_sender:
+        Mutex<NoopRawMutex, Sender<'a, NoopRawMutex, heapless::Vec<u8, MAX_CMD_LEN>, 1>>,
     pub(crate) res_slot: &'a atat::ResponseSlot<INGRESS_BUF_SIZE>,
     cooldown_timer: Cell<Option<Timer>>,
 }
@@ -33,7 +37,7 @@ impl<'a, const INGRESS_BUF_SIZE: usize> ProxyClient<'a, INGRESS_BUF_SIZE> {
         res_slot: &'a atat::ResponseSlot<INGRESS_BUF_SIZE>,
     ) -> Self {
         Self {
-            req_sender,
+            req_sender: Mutex::new(req_sender),
             res_slot,
             cooldown_timer: Cell::new(None),
         }
@@ -57,23 +61,20 @@ impl<'a, const INGRESS_BUF_SIZE: usize> atat::asynch::AtatClient
         let len = cmd.write(&mut buf);
 
         if len < 50 {
-            trace!(
-                "Sending command: {:?}",
-                atat::helpers::LossyStr(&buf[..len])
-            );
+            debug!("🔧 AT Command: {:?}", atat::helpers::LossyStr(&buf[..len]));
         } else {
-            trace!("Sending command with long payload ({} bytes)", len);
+            debug!("🔧 AT Command: Long payload ({} bytes)", len);
         }
 
         if let Some(cooldown) = self.cooldown_timer.take() {
             cooldown.await
         }
 
-        // TODO: Guard against race condition!
+        let sender = self.req_sender.lock().await;
+
         with_timeout(
             Duration::from_secs(1),
-            self.req_sender
-                .send(heapless::Vec::try_from(&buf[..len]).unwrap()),
+            sender.send(heapless::Vec::try_from(&buf[..len]).unwrap()),
         )
         .await
         .map_err(|_| atat::Error::Timeout)?;
@@ -81,13 +82,38 @@ impl<'a, const INGRESS_BUF_SIZE: usize> atat::asynch::AtatClient
         self.cooldown_timer.set(Some(Timer::after_millis(20)));
 
         if !Cmd::EXPECTS_RESPONSE_CODE {
+            debug!("AT Command expects no response, parsing empty response");
+            drop(sender);
             cmd.parse(Ok(&[]))
         } else {
+            debug!(
+                "AT Command expects response, waiting up to {}ms",
+                Cmd::MAX_TIMEOUT_MS
+            );
             let response = self
                 .wait_response(Duration::from_millis(Cmd::MAX_TIMEOUT_MS.into()))
                 .await?;
+
+            // Release sender lock after receiving response
+            drop(sender);
+
             let response: &atat::Response<INGRESS_BUF_SIZE> = &response.borrow();
-            cmd.parse(response.into())
+            let response_result: Result<&[u8], _> = response.into();
+            if let Ok(response_bytes) = &response_result {
+                if response_bytes.len() < 200 {
+                    debug!(
+                        "📡 AT Response: {:?}",
+                        atat::helpers::LossyStr(response_bytes)
+                    );
+                } else {
+                    debug!(
+                        "📡 AT Response: Long response ({} bytes): {:?}",
+                        response_bytes.len(),
+                        atat::helpers::LossyStr(&response_bytes[..200.min(response_bytes.len())])
+                    );
+                }
+            }
+            cmd.parse(response_result)
         }
     }
 }
@@ -121,12 +147,20 @@ impl<'a, const INGRESS_BUF_SIZE: usize> Control<'a, INGRESS_BUF_SIZE> {
         self.link_state() == LinkState::Up
     }
 
+    pub async fn is_denied(&self) -> bool {
+        self.state_ch.is_denied(None)
+    }
+
     pub fn desired_state(&self) -> OperationState {
         self.state_ch.desired_state(None)
     }
 
     pub fn set_desired_state(&self, ps: OperationState) {
         self.state_ch.set_desired_state(ps);
+    }
+
+    pub fn set_apn_config(&self, apn: Apn) {
+        self.state_ch.set_apn_config(apn);
     }
 
     pub async fn wait_for_link_state(&self, link_state: LinkState) {
@@ -141,12 +175,61 @@ impl<'a, const INGRESS_BUF_SIZE: usize> Control<'a, INGRESS_BUF_SIZE> {
         self.state_ch.wait_for_operation_state(ps).await
     }
 
+    /// Get the current Radio Access Technology (2G/3G/4G etc.)
+    pub fn current_rat(&self) -> Option<RatAct> {
+        self.state_ch.current_rat(None)
+    }
+
+    /// Wait for the Radio Access Technology to change (e.g., 3G -> 4G)
+    /// Returns the new RAT value when it changes
+    pub async fn wait_rat_change(&self) -> Option<RatAct> {
+        self.state_ch.wait_rat_change().await
+    }
+
+    /// Wait for either DataEstablished state or powered down indicating something went bad.
+    /// Returns Ok(()) if DataEstablished is reached, or Error if registration is denied.
+    pub async fn wait_for_data_established_or_powered_down(&self) -> Result<(), Error> {
+        use core::task::Poll;
+        use embassy_futures::select::{select, Either};
+
+        let state_runner = self.state_ch.clone();
+
+        let wait_for_data_established = core::future::poll_fn(|cx| {
+            if state_runner.operation_state(Some(cx)) == OperationState::DataEstablished {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        });
+
+        let wait_for_powered_down = core::future::poll_fn(|cx| {
+            if state_runner.operation_state(Some(cx)) == OperationState::PowerDown {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        });
+
+        match select(wait_for_data_established, wait_for_powered_down).await {
+            Either::First(_) => {
+                info!("✅ Data connection established successfully");
+                Ok(())
+            }
+            Either::Second(_) => {
+                error!("❌ Module powered down while waiting for data connection");
+                Err(Error::Network(
+                    crate::command::network_service::types::Error::RegistrationDenied,
+                ))
+            }
+        }
+    }
+
     pub async fn get_signal_quality(&self) -> Result<SignalQuality, Error> {
-        Ok(self.send(&GetSignalQuality).await?)
+        self.send(&GetSignalQuality).await
     }
 
     pub async fn get_operator(&self) -> Result<OperatorSelection, Error> {
-        Ok(self.send(&GetOperatorSelection).await?)
+        self.send(&GetOperatorSelection).await
     }
 
     pub async fn get_version(&self) -> Result<FirmwareVersion, Error> {
@@ -173,5 +256,26 @@ impl<'a, const INGRESS_BUF_SIZE: usize> Control<'a, INGRESS_BUF_SIZE> {
         }
 
         Ok((&self.at_client).send_retry::<Cmd>(cmd).await?)
+    }
+
+    pub async fn get_apn_info(&self) -> Result<heapless::String<62>, Error> {
+        let pdp_context = self.send(&GetPDPContextDefinition).await?;
+
+        if let Some(config) = pdp_context.first() {
+            Ok(config.apn.clone())
+        } else {
+            Err(Error::_Unknown)
+        }
+    }
+
+    pub async fn get_ccid(&self) -> Result<u128, Error> {
+        let ccid = self.send(&GetCCID).await?;
+
+        Ok(ccid.ccid)
+    }
+    pub async fn get_gpio_value(&self, gpio_id: u8) -> Result<u8, Error> {
+        let value = self.send(&ReadGpioPin { gpio_id }).await?;
+
+        Ok(value.gpio_val)
     }
 }

--- a/src/asynch/network.rs
+++ b/src/asynch/network.rs
@@ -1,5 +1,8 @@
 use core::{cmp::Ordering, future::poll_fn, marker::PhantomData, task::Poll};
 
+#[cfg(feature = "use-upsd-context-activation")]
+use core::net::Ipv4Addr;
+
 use crate::{
     asynch::state::OperationState,
     command::{
@@ -26,7 +29,7 @@ use crate::{
             SetPDPContextState,
         },
     },
-    config::CellularConfig,
+    config::{Apn, CellularConfig},
     error::Error,
     modules::ModuleParams,
     registration::ProfileState,
@@ -65,40 +68,82 @@ where
     /// Returns an error if any of the internal network operations fail.
     ///
     async fn register_network(&mut self, mcc_mnc: Option<()>) -> Result<(), Error> {
+        info!("🔧 NetDevice::register_network() - Starting network registration process");
+        debug!(
+            "NetDevice::register_network() - MCC/MNC parameter: {:?}",
+            mcc_mnc
+        );
+
+        info!("NetDevice::register_network() - Calling prepare_connect()");
         self.prepare_connect().await?;
+        info!("NetDevice::register_network() - prepare_connect() completed successfully");
 
         if mcc_mnc.is_none() {
+            info!("NetDevice::register_network() - No MCC/MNC specified, setting automatic network selection");
             // If no MCC/MNC is given, make sure we are in automatic network
             // selection mode.
 
             // Set automatic operator selection, if not already set
+            debug!("NetDevice::register_network() - Getting current operator selection");
             let OperatorSelection { mode, .. } = self.at_client.send(&GetOperatorSelection).await?;
+            info!(
+                "NetDevice::register_network() - Current operator selection mode: {:?}",
+                mode
+            );
 
             if mode != OperatorSelectionMode::Automatic {
+                info!("NetDevice::register_network() - Switching to automatic operator selection mode");
                 // Don't check error code here as some modules can
                 // return an error as we still have the radio off (but they still
                 // obey)
-                let _ = self
+                match self
                     .at_client
                     .send(&SetOperatorSelection {
                         mode: OperatorSelectionMode::Automatic,
                         format: None,
                     })
-                    .await;
+                    .await {
+                    Ok(_) => info!("NetDevice::register_network() - Successfully set automatic operator selection"),
+                    Err(e) => warn!("NetDevice::register_network() - Failed to set automatic operator selection (this may be expected): {:?}", e)
+                }
+            } else {
+                info!(
+                    "NetDevice::register_network() - Already in automatic operator selection mode"
+                );
             }
         }
 
         // Reset the current registration status
-        self.ch.update_registration_with(|f| f.reset());
+        info!("NetDevice::register_network() - Resetting registration status");
+        self.ch.update_registration_with(|f| {
+            f.reset();
+            false // Reset doesn't constitute a RAT change
+        });
+        debug!("NetDevice::register_network() - Registration status reset completed");
 
-        self.at_client
+        info!("NetDevice::register_network() - Setting module functionality to Full");
+        match self
+            .at_client
             .send(&SetModuleFunctionality {
                 fun: Functionality::Full,
                 rst: None,
             })
-            .await?;
+            .await
+        {
+            Ok(_) => info!(
+                "NetDevice::register_network() - Successfully set module functionality to Full"
+            ),
+            Err(e) => {
+                error!(
+                    "NetDevice::register_network() - Failed to set module functionality: {:?}",
+                    e
+                );
+                return Err(e.into());
+            }
+        }
 
         if mcc_mnc.is_some() {
+            error!("NetDevice::register_network() - Manual operator selection with MCC/MNC is not implemented!");
             // TODO: If MCC & MNC is set, register with manual operator selection.
             // This is currently not supported!
 
@@ -123,39 +168,107 @@ where
             unimplemented!()
         }
 
+        info!("✅ NetDevice::register_network() - Network registration completed successfully");
         Ok(())
     }
 
     async fn prepare_connect(&mut self) -> Result<(), Error> {
+        info!("🔧 NetDevice::prepare_connect() - Starting connection preparation");
+
         // CREG URC
-        self.at_client
+        debug!("NetDevice::prepare_connect() - Setting up CREG URC (Network Registration)");
+        match self
+            .at_client
             .send(&SetNetworkRegistrationStatus {
                 n: NetworkRegistrationUrcConfig::UrcEnabled,
             })
-            .await?;
-
+            .await
+        {
+            Ok(_) => info!("NetDevice::prepare_connect() - Successfully enabled CREG URC"),
+            Err(e) => {
+                error!(
+                    "NetDevice::prepare_connect() - Failed to enable CREG URC: {:?}",
+                    e
+                );
+                return Err(e.into());
+            }
+        }
         // CGREG URC
-        self.at_client
+        debug!("NetDevice::prepare_connect() - Setting up CGREG URC (GPRS Registration)");
+        match self
+            .at_client
             .send(&SetGPRSNetworkRegistrationStatus {
                 n: GPRSNetworkRegistrationUrcConfig::UrcEnabled,
             })
-            .await?;
+            .await
+        {
+            Ok(_) => info!("NetDevice::prepare_connect() - Successfully enabled CGREG URC"),
+            Err(e) => {
+                error!(
+                    "NetDevice::prepare_connect() - Failed to enable CGREG URC: {:?}",
+                    e
+                );
+                return Err(e.into());
+            }
+        }
 
         // CEREG URC
-        self.at_client
+        debug!("NetDevice::prepare_connect() - Setting up CEREG URC (EPS Registration)");
+        match self
+            .at_client
             .send(&SetEPSNetworkRegistrationStatus {
                 n: EPSNetworkRegistrationUrcConfig::UrcEnabled,
             })
-            .await?;
-
-        for _ in 0..10 {
-            if self.at_client.send(&GetCIMI).await.is_ok() {
-                break;
+            .await
+        {
+            Ok(_) => info!("NetDevice::prepare_connect() - Successfully enabled CEREG URC"),
+            Err(e) => {
+                error!(
+                    "NetDevice::prepare_connect() - Failed to enable CEREG URC: {:?}",
+                    e
+                );
+                return Err(e.into());
             }
-
-            Timer::after_secs(1).await;
         }
 
+        info!("NetDevice::prepare_connect() - Starting module readiness check with CIMI command");
+        let mut ready = false;
+        for attempt in 0..10 {
+            debug!(
+                "NetDevice::prepare_connect() - CIMI attempt {}/{}",
+                attempt + 1,
+                10
+            );
+            match self.at_client.send(&GetCIMI).await {
+                Ok(cimi_response) => {
+                    info!(
+                        "NetDevice::prepare_connect() - Module is ready! CIMI response: {:?}",
+                        cimi_response.imsi
+                    );
+                    ready = true;
+                    break;
+                }
+                Err(e) => {
+                    warn!(
+                        "NetDevice::prepare_connect() - CIMI attempt {}/{} failed: {:?}",
+                        attempt + 1,
+                        10,
+                        e
+                    );
+                    if attempt < 9 {
+                        debug!("NetDevice::prepare_connect() - Waiting 1 second before next CIMI attempt");
+                        Timer::after_secs(1).await;
+                    }
+                }
+            }
+        }
+
+        if !ready {
+            error!("NetDevice::prepare_connect() - Module failed to respond to CIMI after 10 attempts!");
+            return Err(Error::Generic(crate::error::GenericError::Timeout));
+        }
+
+        info!("✅ NetDevice::prepare_connect() - Connection preparation completed successfully");
         Ok(())
     }
 
@@ -180,7 +293,7 @@ where
 
     /// Reset the module by sending AT CFUN command
     async fn soft_reset(&mut self, sim_reset: bool) -> Result<(), Error> {
-        trace!(
+        debug!(
             "Attempting to soft reset of the modem with sim reset: {}.",
             sim_reset
         );
@@ -210,44 +323,87 @@ where
     /// Check if we are registered to a network technology (uses +CxREG family
     /// commands)
     async fn wait_network_registered(&mut self, timeout: Duration) -> Result<(), Error> {
-        let state_runner = self.ch.clone();
-        let update_fut = async {
-            loop {
-                self.update_registration().await;
+        info!(
+            "🔧 NetDevice::wait_network_registered() - Starting to wait for network registration (timeout: {:?})",
+            timeout
+        );
 
-                Timer::after_millis(300).await;
+        let state_runner = self.ch.clone();
+
+        let wait_fut = async {
+            loop {
+                self.update_registration().await?;
+
+                if state_runner.is_registered(None) {
+                    info!("✅ Successfully registered to network");
+                    return Ok(());
+                }
+
+                Timer::after_secs(1).await;
             }
         };
 
-        Ok(embassy_time::with_timeout(
-            timeout,
-            select(
-                update_fut,
-                poll_fn(|cx| match state_runner.is_registered(Some(cx)) {
-                    true => Poll::Ready(()),
-                    false => Poll::Pending,
-                }),
-            ),
-        )
-        .await
-        .map(drop)?)
+        embassy_time::with_timeout(timeout, wait_fut)
+            .await
+            .map_err(|_| {
+                error!(
+                    "❌Failed to register within timeout"
+                );
+                Error::Generic(crate::error::GenericError::Timeout)
+            })?
     }
 
-    async fn update_registration(&mut self) {
-        if let Ok(reg) = self.at_client.send(&GetNetworkRegistrationStatus).await {
-            self.ch
-                .update_registration_with(|state| state.compare_and_set(reg.into()));
+    async fn update_registration(&mut self) -> Result<(), Error> {
+        // Check Network Registration (CREG)
+        match self.at_client.send(&GetNetworkRegistrationStatus).await {
+            Ok(reg) => {
+                
+                debug!("CREG status: {:?}", reg.stat);
+
+                self.ch
+                    .update_registration_with(|state| state.compare_and_set(reg.into()));
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to get CREG status: {:?}",
+                    e
+                );
+            }
         }
 
-        if let Ok(reg) = self.at_client.send(&GetGPRSNetworkRegistrationStatus).await {
-            self.ch
-                .update_registration_with(|state| state.compare_and_set(reg.into()));
+        // Check GPRS Registration (CGREG)
+        match self.at_client.send(&GetGPRSNetworkRegistrationStatus).await {
+            Ok(reg) => {
+                debug!("CGREG status: {:?}", reg.stat);
+                self.ch
+                    .update_registration_with(|state| state.compare_and_set(reg.into()));
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to get CGREG status: {:?}",
+                    e
+                );
+            }
         }
 
-        if let Ok(reg) = self.at_client.send(&GetEPSNetworkRegistrationStatus).await {
-            self.ch
-                .update_registration_with(|state| state.compare_and_set(reg.into()));
+        // Check EPS Registration (CEREG)
+        match self.at_client.send(&GetEPSNetworkRegistrationStatus).await {
+            Ok(reg) => {
+                debug!("CEREG status: {:?}", reg.stat);
+                self.ch
+                    .update_registration_with(|state| state.compare_and_set(reg.into()));
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to get CEREG status: {:?}",
+                    e
+                );
+            }
         }
+
+        trace!("Registration update completed");
+
+        Ok(())
     }
 
     async fn radio_off(&mut self) -> Result<(), Error> {
@@ -306,6 +462,7 @@ where
             .await
             {
                 Either::First(_) => {
+                    info!("desired state chagne, run to desired state");
                     self.run_to_desired().await?;
                 }
                 Either::Second(false) => {
@@ -314,6 +471,7 @@ where
                     self.run_to_desired().await?;
                 }
                 Either::Second(true) => {
+                    info!("Network registration changed");
                     // This flag will be set if we had been knocked out
                     // of our PDP context by a network outage and need
                     // to get it back again; make sure to get this in the
@@ -348,22 +506,52 @@ where
                         .await
                 }
                 (OperationState::Initialized, Ordering::Greater) => {
+                    info!(
+                        "NetDevice::run_to_desired() - Transitioning from Initialized to Connected"
+                    );
+                    debug!("NetDevice::run_to_desired() - Starting network registration process");
+
                     self.register_network(None).await?;
+                    info!("NetDevice::run_to_desired() - Network registration completed, waiting for registration confirmation");
+
                     self.wait_network_registered(Duration::from_secs(180))
                         .await?;
+
+                    info!("NetDevice::run_to_desired() - Network registration confirmed, setting state to Connected");
                     self.ch.set_operation_state(OperationState::Connected);
                 }
                 (OperationState::Connected, Ordering::Greater) => {
-                    match self.connect(C::APN, C::PROFILE_ID, C::CONTEXT_ID).await {
+                    info!("NetDevice::run_to_desired() - Transitioning from Connected to DataEstablished");
+                    info!("NetDevice::run_to_desired() - Operation state is connected, establishing data connection");
+                    let apn = self.ch.get_apn_config();
+                    match &apn {
+                        crate::config::Apn::Given { name, .. } => {
+                            info!(
+                                "NetDevice::run_to_desired() - Using configured APN: {}",
+                                name
+                            );
+                        }
+                        crate::config::Apn::None => {
+                            info!(
+                                "NetDevice::run_to_desired() - Using default APN (none specified)"
+                            );
+                        }
+                    }
+
+                    match self.connect(apn, C::PROFILE_ID, C::CONTEXT_ID).await {
                         Ok(_) => {
+                            info!("NetDevice::run_to_desired() - Data connection established successfully");
                             #[cfg(not(feature = "use-upsd-context-activation"))]
                             self.ch
                                 .set_profile_state(crate::registration::ProfileState::ShouldBeUp);
 
                             self.ch.set_operation_state(OperationState::DataEstablished);
+                            info!("NetDevice::run_to_desired() - State set to DataEstablished");
                         }
                         Err(err) => {
+                            error!("NetDevice::run_to_desired() - Failed to establish data connection: {:?}", err);
                             // Switch radio off after failure
+                            warn!("NetDevice::run_to_desired() - Switching radio off after connection failure");
                             let _ = self.radio_off().await;
                             return Err(err);
                         }
@@ -389,12 +577,26 @@ where
     #[allow(unused_variables)]
     async fn connect(
         &mut self,
-        apn_info: crate::config::Apn<'_>,
+        apn_info: crate::config::Apn,
         profile_id: ProfileId,
         context_id: ContextId,
     ) -> Result<(), Error> {
+        debug!("NetDevice::connect() - APN info: {:?}", apn_info);
+
         #[cfg(not(feature = "use-upsd-context-activation"))]
-        self.define_context(context_id, apn_info).await?;
+        {
+            debug!("NetDevice::connect() - Defining PDP context");
+            match self.define_context(context_id, apn_info).await {
+                Ok(_) => debug!("NetDevice::connect() - Successfully defined PDP context"),
+                Err(e) => {
+                    error!(
+                        "NetDevice::connect() - Failed to define PDP context: {:?}",
+                        e
+                    );
+                    return Err(e);
+                }
+            }
+        }
 
         // This step _shouldn't_ be necessary.  However, for reasons I don't
         // understand, SARA-R4 can be registered but not attached (i.e. AT+CGATT
@@ -403,24 +605,75 @@ where
         // return 1 and then (c) check that a context is active with AT+CGACT or
         // using AT+UPSD (even for EUTRAN). Since this sequence works for both
         // RANs, it is best to be consistent.
+        debug!("NetDevice::connect() - Waiting for network attachment (CGATT)");
         let mut attached = false;
-        for _ in 0..10 {
-            if let Ok(true) = self.is_network_attached().await {
-                attached = true;
-                break;
-            };
-            Timer::after_secs(1).await;
+        for attempt in 0..10 {
+            debug!(
+                "NetDevice::connect() - Network attachment attempt {}/{}",
+                attempt + 1,
+                10
+            );
+            match self.is_network_attached().await {
+                Ok(true) => {
+                    info!(
+                        "NetDevice::connect() - Network successfully attached on attempt {}",
+                        attempt + 1
+                    );
+                    attached = true;
+                    break;
+                }
+                Ok(false) => {
+                    warn!(
+                        "NetDevice::connect() - Network not attached yet (attempt {})",
+                        attempt + 1
+                    );
+                }
+                Err(e) => {
+                    warn!("NetDevice::connect() - Error checking attachment status on attempt {}: {:?}", attempt + 1, e);
+                }
+            }
+
+            debug!("NetDevice::connect() - Waiting 1 second before next attachment check");
+            Timer::after_secs(2).await;
         }
+
         if !attached {
+            error!("NetDevice::connect() - Failed to attach to network after 10 attempts!");
             return Err(Error::AttachTimeout);
         }
 
+        debug!("NetDevice::connect() - Network attached, now activating context");
+
         // Activate the context
         #[cfg(feature = "use-upsd-context-activation")]
-        self.activate_context_upsd(profile_id, apn_info).await?;
+        {
+            debug!("NetDevice::connect() - Using UPSD context activation");
+            match self.activate_context_upsd(profile_id, apn_info).await {
+                Ok(_) => debug!("NetDevice::connect() - Successfully activated context via UPSD"),
+                Err(e) => {
+                    error!(
+                        "NetDevice::connect() - Failed to activate context via UPSD: {:?}",
+                        e
+                    );
+                    return Err(e);
+                }
+            }
+        }
         #[cfg(not(feature = "use-upsd-context-activation"))]
-        self.activate_context(context_id, profile_id).await?;
+        {
+            match self.activate_context(context_id, profile_id).await {
+                Ok(_) => debug!("NetDevice::connect() - Successfully activated context via 3GPP"),
+                Err(e) => {
+                    error!(
+                        "NetDevice::connect() - Failed to activate context via 3GPP: {:?}",
+                        e
+                    );
+                    return Err(e);
+                }
+            }
+        }
 
+        debug!("✅ NetDevice::connect() - Data connection setup completed successfully");
         Ok(())
     }
 
@@ -429,7 +682,7 @@ where
     async fn define_context(
         &mut self,
         cid: ContextId,
-        apn_info: crate::config::Apn<'_>,
+        apn_info: crate::config::Apn,
     ) -> Result<(), Error> {
         use crate::command::psn::{
             types::AuthenticationType, SetAuthParameters, SetPDPContextDefinition,
@@ -452,11 +705,12 @@ where
             password,
         } = apn_info
         {
+            info!("Will try to set DPD context with APN NAME {}", name);
             self.at_client
                 .send(&SetPDPContextDefinition {
                     cid,
                     pdp_type: "IP",
-                    apn: name,
+                    apn: name.as_str(),
                 })
                 .await?;
 
@@ -465,8 +719,8 @@ where
                     .send(&SetAuthParameters {
                         cid,
                         auth_type: AuthenticationType::Auto,
-                        username,
-                        password: password.unwrap_or_default(),
+                        username: username.as_str(),
+                        password: password.unwrap_or_default().as_str(),
                     })
                     .await?;
             }
@@ -484,9 +738,25 @@ where
 
     // Make sure we are attached to the cellular network.
     async fn is_network_attached(&mut self) -> Result<bool, Error> {
+        debug!("NetDevice::is_network_attached() - Checking GPRS attachment status");
         // Check for AT+CGATT to return 1
-        let GPRSAttached { state } = self.at_client.send(&GetGPRSAttached).await?;
-        Ok(state == GPRSAttachedState::Attached)
+        match self.at_client.send(&GetGPRSAttached).await {
+            Ok(GPRSAttached { state }) => {
+                let attached = state == GPRSAttachedState::Attached;
+                debug!(
+                    "NetDevice::is_network_attached() - GPRS state: {:?}, attached: {}",
+                    state, attached
+                );
+                Ok(attached)
+            }
+            Err(e) => {
+                error!(
+                    "NetDevice::is_network_attached() - Failed to get GPRS attachment status: {:?}",
+                    e
+                );
+                Err(e.into())
+            }
+        }
     }
 
     /// Activate context using AT+UPSD commands.
@@ -505,7 +775,7 @@ where
         } = apn_info
         {
             self.at_client
-                .send(&psn::SetPacketSwitchedConfig {
+                .send(&SetPacketSwitchedConfig {
                     profile_id,
                     param: psn::types::PacketSwitchedParam::APN(
                         String::<99>::try_from(name).unwrap(),
@@ -516,7 +786,7 @@ where
             // Set up the user name
             if let Some(user_name) = username {
                 self.at_client
-                    .send(&psn::SetPacketSwitchedConfig {
+                    .send(&SetPacketSwitchedConfig {
                         profile_id,
                         param: psn::types::PacketSwitchedParam::Username(
                             String::<64>::try_from(user_name).unwrap(),
@@ -528,7 +798,7 @@ where
             // Set up the password
             if let Some(password) = password {
                 self.at_client
-                    .send(&psn::SetPacketSwitchedConfig {
+                    .send(&SetPacketSwitchedConfig {
                         profile_id,
                         param: psn::types::PacketSwitchedParam::Password(
                             String::<64>::try_from(password).unwrap(),
@@ -539,22 +809,22 @@ where
         }
         // Set up the dynamic IP address assignment.
         self.at_client
-            .send(&psn::SetPacketSwitchedConfig {
+            .send(&SetPacketSwitchedConfig {
                 profile_id,
-                param: psn::types::PacketSwitchedParam::IPAddress(Ipv4Addr::unspecified().into()),
+                param: PacketSwitchedParam::IPAddress(Ipv4Addr::unspecified().into()),
             })
             .await?;
 
         // Automatic authentication protocol selection
         self.at_client
-            .send(&psn::SetPacketSwitchedConfig {
+            .send(&SetPacketSwitchedConfig {
                 profile_id,
                 param: psn::types::PacketSwitchedParam::Authentication(AuthenticationType::Auto),
             })
             .await?;
 
         self.at_client
-            .send(&psn::SetPacketSwitchedAction {
+            .send(&SetPacketSwitchedAction {
                 profile_id,
                 action: psn::types::PacketSwitchedAction::Activate,
             })
@@ -568,7 +838,7 @@ where
     async fn activate_context(
         &mut self,
         cid: ContextId,
-        _profile_id: ProfileId,
+        #[allow(unused_variables)] profile_id: ProfileId,
     ) -> Result<(), Error> {
         for _ in 0..5 {
             #[cfg(feature = "sara-r422")]
@@ -606,19 +876,24 @@ where
                 // [Re]attach a PDP context to an internal module profile
                 #[cfg(feature = "context-mapping-required")]
                 {
+                    use crate::command::psn::{
+                        types::{
+                            PacketSwitchedAction as PSAction, PacketSwitchedParam, ProtocolType,
+                        },
+                        SetPacketSwitchedAction, SetPacketSwitchedConfig,
+                    };
+
                     self.at_client
-                        .send(&psn::SetPacketSwitchedConfig {
-                            profile_id: _profile_id,
-                            param: psn::types::PacketSwitchedParam::ProtocolType(
-                                psn::types::ProtocolType::IPv4,
-                            ),
+                        .send(&SetPacketSwitchedConfig {
+                            profile_id,
+                            param: PacketSwitchedParam::ProtocolType(ProtocolType::IPv4),
                         })
                         .await?;
 
                     self.at_client
-                        .send(&psn::SetPacketSwitchedConfig {
-                            profile_id: _profile_id,
-                            param: psn::types::PacketSwitchedParam::MapProfile(cid),
+                        .send(&SetPacketSwitchedConfig {
+                            profile_id,
+                            param: PacketSwitchedParam::MapProfile(cid),
                         })
                         .await?;
 
@@ -627,9 +902,9 @@ where
                     // until the +UUPSDA URC comes back,
                     #[cfg(feature = "sara-r5")]
                     self.at_client
-                        .send(&psn::SetPacketSwitchedAction {
+                        .send(&SetPacketSwitchedAction {
                             profile_id,
-                            action: psn::types::PacketSwitchedAction::Activate,
+                            action: PSAction::Activate,
                         })
                         .await?;
                 }

--- a/src/asynch/runner.rs
+++ b/src/asynch/runner.rs
@@ -1,4 +1,4 @@
-use core::{default, future::poll_fn, task::Poll};
+use core::{future::poll_fn, task::Poll};
 
 use crate::{
     asynch::{network::NetDevice, state::OperationState},
@@ -13,8 +13,7 @@ use crate::{
         device_lock::{responses::PinStatus, types::PinStatusCode, GetPinStatus},
         general::{responses::FirmwareVersion, GetCCID, GetFirmwareVersion, GetModelId},
         ip_transport_layer::{
-            responses::CreateSocketResponse,
-            types::{AoNState, PreferredProtocolType, SocketProtocol},
+            types::{PreferredProtocolType, SocketProtocol},
             CloseSocket, CreateSocket,
         },
         ipc::SetMultiplexing,
@@ -49,17 +48,17 @@ use atat::{
 
 use embassy_futures::{
     join::join,
-    select::{select, select3, Either3},
+    select::{select3, Either3},
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
-use embassy_time::{with_timeout, Duration, Instant, Timer};
+use embassy_time::{Duration, Instant, Timer};
 use embedded_io_async::Write as _;
 
 pub(crate) const URC_SUBSCRIBERS: usize = 2;
 
 pub(crate) const MAX_CMD_LEN: usize = 128;
 
-pub const CMUX_MAX_FRAME_SIZE: usize = 128;
+pub const CMUX_MAX_FRAME_SIZE: usize = 256;
 pub const CMUX_CHANNEL_SIZE: usize = CMUX_MAX_FRAME_SIZE * 4;
 
 pub const CMUX_CHANNELS: usize = 2;
@@ -277,18 +276,25 @@ where
         };
 
         // Rid the transport of garbage bytes from powercycle
-        loop {
-            let len = self
-                .transport
-                .fill_buf()
-                .await
-                .map(|s| s.len())
-                .unwrap_or_default();
-            self.transport.consume(len);
-            if len == 0 {
-                break;
+        embassy_time::with_timeout(Duration::from_millis(100), async {
+            loop {
+                let len = self
+                    .transport
+                    .fill_buf()
+                    .await
+                    .map(|s| s.len())
+                    .unwrap_or_default();
+                self.transport.consume(len);
+                info!("Flushed {} bytes from transport", len);
+                if len == 0 {
+                    break;
+                }
             }
-        }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            warn!("Transport buffer drain timeout - continuing anyway");
+        });
 
         // Probe all possible baudrates with the goal of establishing initial
         // communication with the module, so we can reconfigure it for desired
@@ -412,50 +418,30 @@ where
         // Check sim status
         let sim_status = async {
             for _ in 0..2 {
-                if let Ok(PinStatus {
-                    code: PinStatusCode::Ready,
-                }) = at_client.send(&GetPinStatus).await
-                {
-                    debug!("SIM is ready");
-                    return Ok(());
+                if let Ok(res) = at_client.send_retry(&GetCCID).await {
+                    return Ok(res.ccid);
                 }
 
                 Timer::after_secs(1).await;
             }
-
-            // There was an error initializing the SIM
-            // We've seen issues on uBlox-based devices, as a precation, we'll cycle
-            // the modem here through minimal/full functional state.
-            at_client
-                .send(&SetModuleFunctionality {
-                    fun: self
-                        .ch
-                        .module()
-                        .ok_or(Error::Uninitialized)?
-                        .radio_off_cfun(),
-                    rst: None,
-                })
-                .await?;
-            at_client
-                .send(&SetModuleFunctionality {
-                    fun: Functionality::Full,
-                    rst: None,
-                })
-                .await?;
-
             Err(Error::SimCard)
         };
 
-        sim_status.await?;
-
-        let ccid = at_client.send_retry(&GetCCID).await?;
-        info!("CCID: {}", ccid.ccid);
+        match sim_status.await {
+            Ok(ccid) => {
+                info!("CCID: {}", ccid);
+            }
+            Err(_) => {
+                warn!("Faild to get CCID, SIM card missing or not ready. continuing anyway");
+            }
+        };
 
         at_client
             .send_retry(&SetResultCodeSelection {
                 value: ResultCodeSelection::ConnectOnly,
             })
-            .await?;
+            .await
+            .ok();
 
         #[cfg(all(
             feature = "ucged",
@@ -659,6 +645,8 @@ where
             };
 
             let mux_fut = async {
+                info!("initializing multiplexer");
+
                 // Must be large enough to hold 'AT+CMUX=0,0,5,512,10,3,40,10,2\r\n'
                 let mut buf = [0u8; 32];
                 {
@@ -668,6 +656,7 @@ where
                         &mut buf,
                         C::AT_CONFIG,
                     );
+                    debug!("sending cmux at command");
 
                     at_client
                         .send(&SetMultiplexing {
@@ -698,6 +687,7 @@ where
                 })
                 .await;
 
+                debug!("DONE flushing read channel will wait 3 sec now");
                 let (mut tx, mut rx) = self.transport.split_ref();
 
                 // Signal to the rest of the driver, that the MUX is operational and running
@@ -705,6 +695,7 @@ where
                     // TODO: It should be possible to check on ChannelLines,
                     // when the MUX is opened successfully, instead of waiting a fixed time
                     Timer::after_secs(3).await;
+                    debug!("DONE waiting 3 sec set operation state to initialized");
                     self.ch.set_operation_state(OperationState::Initialized);
                 };
 

--- a/src/asynch/state.rs
+++ b/src/asynch/state.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use crate::command::Urc;
+use crate::command::network_service::types::RatAct;
+use crate::config::Apn;
 use core::cell::RefCell;
 use core::future::poll_fn;
 use core::task::{Context, Poll};
@@ -53,6 +54,11 @@ impl State {
                 registration_state: RegistrationState::new(),
                 state_waker: WakerRegistration::new(),
                 registration_waker: WakerRegistration::new(),
+                rat_waker: WakerRegistration::new(),
+                #[cfg(not(feature = "automatic-apn"))]
+                apn_config: Apn::None,
+                #[cfg(any(feature = "automatic-apn"))]
+                apn_config: Apn::Automatic,
             })),
         }
     }
@@ -67,6 +73,8 @@ pub struct Shared {
     registration_state: RegistrationState,
     state_waker: WakerRegistration,
     registration_waker: WakerRegistration,
+    rat_waker: WakerRegistration,
+    apn_config: Apn,
 }
 
 #[derive(Clone)]
@@ -92,19 +100,33 @@ impl<'d> Runner<'d> {
         });
     }
 
-    pub fn update_registration_with(&self, f: impl FnOnce(&mut RegistrationState)) {
+    pub fn update_registration_with(&self, f: impl FnOnce(&mut RegistrationState) -> bool) {
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
-            let prev = s.registration_state.is_registered();
-            f(&mut s.registration_state);
-            if prev != s.registration_state.is_registered() {
+            let prev_registered = s.registration_state.is_registered();
+            let prev_state = s.registration_state.clone();
+
+            let rat_changed = f(&mut s.registration_state);
+
+            let new_registered = s.registration_state.is_registered();
+
+            if prev_registered != new_registered {
                 info!(
-                    "Cellular registration status changed! Registered: {:?} -> {:?}",
-                    prev,
-                    s.registration_state.is_registered()
+                    "🔄 Cellular registration status changed! Registered: {:?} -> {:?}",
+                    prev_registered, new_registered
                 );
-            }
+                debug!(
+                    "State: Registration state details changed: {:?}",
+                     s.registration_state
+                );
+            } 
+
             s.registration_waker.wake();
+
+            // Wake RAT waker if RAT changed
+            if rat_changed {
+                s.rat_waker.wake();
+            }
         })
     }
 
@@ -115,6 +137,16 @@ impl<'d> Runner<'d> {
                 s.registration_waker.register(cx.waker());
             }
             s.registration_state.is_registered()
+        })
+    }
+
+    pub fn is_denied(&self, cx: Option<&mut Context>) -> bool {
+        self.shared.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            if let Some(cx) = cx {
+                s.registration_waker.register(cx.waker());
+            }
+            s.registration_state.is_denied()
         })
     }
 
@@ -153,9 +185,44 @@ impl<'d> Runner<'d> {
     pub fn set_operation_state(&self, state: OperationState) {
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
-            s.operation_state = state;
-            s.state_waker.wake();
+            let prev_state = s.operation_state;
+            if prev_state != state {
+                info!(
+                    "🔄 Operation state changed: {:?} -> {:?}",
+                    prev_state, state
+                );
+                s.operation_state = state;
+                s.state_waker.wake();
+            } else {
+                debug!("State: Operation state unchanged: {:?}", state);
+            }
         });
+    }
+
+    pub fn set_apn_config(&self, apn: Apn) {
+        self.shared.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            let prev_apn = s.apn_config.clone();
+            let changed = match (&prev_apn, &apn) {
+                (Apn::Given { name: n1, .. }, Apn::Given { name: n2, .. }) => n1 != n2,
+                (Apn::None, Apn::None) => false,
+                _ => true,
+            };
+
+            if changed {
+                info!("🔄 APN configuration changed: {:?} -> {:?}", prev_apn, apn);
+            } else {
+                debug!("State: APN configuration unchanged");
+            }
+            s.apn_config = apn;
+        });
+    }
+
+    pub fn get_apn_config(&self) -> Apn {
+        self.shared.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            s.apn_config.clone()
+        })
     }
 
     pub fn operation_state(&self, cx: Option<&mut Context>) -> OperationState {
@@ -169,6 +236,11 @@ impl<'d> Runner<'d> {
     }
 
     pub fn set_desired_state(&self, ps: OperationState) {
+        info!(
+            "🔄 Desired state changed: {:?} -> {:?}",
+            self.desired_state(None),
+            ps
+        );
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
             s.desired_state = ps;
@@ -248,6 +320,32 @@ impl<'d> Runner<'d> {
             let current_state = self.is_registered(Some(cx));
             if current_state != old_state {
                 return Poll::Ready(current_state);
+            }
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Get the current Radio Access Technology (2G/3G/4G etc.)
+    pub fn current_rat(&self, cx: Option<&mut Context>) -> Option<RatAct> {
+        self.shared.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            if let Some(cx) = cx {
+                s.rat_waker.register(cx.waker());
+            }
+            s.registration_state.current_act()
+        })
+    }
+
+    /// Wait for the Radio Access Technology to change (e.g., 3G -> 4G)
+    /// Returns the new RAT value
+    pub async fn wait_rat_change(&self) -> Option<RatAct> {
+        let old_rat = self.current_rat(None);
+
+        poll_fn(|cx| {
+            let current_rat = self.current_rat(Some(cx));
+            if current_rat != old_rat {
+                return Poll::Ready(current_rat);
             }
             Poll::Pending
         })

--- a/src/command/network_service/types.rs
+++ b/src/command/network_service/types.rs
@@ -58,6 +58,7 @@ pub enum RatAct {
 }
 
 #[derive(Clone, PartialEq, Eq, AtatEnum)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum NetworkRegistrationUrcConfig {
     /// • 0 (default value and factory-programmed value): network registration URC disabled
     UrcDisabled = 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,8 +98,6 @@ pub trait CellularConfig<'a> {
     const PROFILE_ID: ProfileId = ProfileId(1);
     const CONTEXT_ID: ContextId = ContextId(1);
 
-    const APN: Apn<'a> = Apn::None;
-
     #[cfg(feature = "ppp")]
     const PPP_CONFIG: embassy_net_ppp::Config<'a>;
 
@@ -113,6 +111,10 @@ pub trait CellularConfig<'a> {
 
     fn vint_pin(&mut self) -> Option<&mut Self::VintPin> {
         None
+    }
+
+    fn apn_lookup(&mut self, _mcc_mnc: (u16, u16)) -> Apn {
+        Apn::None
     }
 }
 
@@ -129,18 +131,19 @@ pub enum OperatorFormat {
 }
 
 #[derive(Debug, Clone)]
-pub enum Apn<'a> {
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Apn {
     None,
     Given {
-        name: &'a str,
-        username: Option<&'a str>,
-        password: Option<&'a str>,
+        name: heapless::String<62>,
+        username: Option<heapless::String<10>>,
+        password: Option<heapless::String<10>>,
     },
     #[cfg(any(feature = "automatic-apn"))]
     Automatic,
 }
 
-impl Default for Apn<'_> {
+impl Default for Apn {
     fn default() -> Self {
         Self::None
     }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -103,11 +103,11 @@ impl Module {
             b"LARA-R6001D" => Self::LaraR6(lara_r6::LaraR6),
             #[cfg(any(feature = "any-module", feature = "toby-r2"))]
             b"TOBY-R200" | b"TOBY-R201" | b"TOBY-R202" => Self::TobyR2(toby_r2::TobyR2),
-            id => {
+            _id => {
                 #[cfg(feature = "defmt")]
-                warn!("Attempting to run {=[u8]:a} using generic module parameters! This may or may not work.", id);
+                warn!("Attempting to run {=[u8]:a} using generic module parameters! This may or may not work.", _id);
                 #[cfg(feature = "log")]
-                warn!("Attempting to run {:?} using generic module parameters! This may or may not work.", id);
+                warn!("Attempting to run {:?} using generic module parameters! This may or may not work.", _id);
                 Self::Generic(Generic)
             }
         }

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -14,6 +14,7 @@ use embassy_time::{Duration, Instant};
 use heapless::String;
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CellularRegistrationStatus {
     status: Status,
     updated: Option<Instant>,
@@ -134,7 +135,8 @@ pub enum ProfileState {
 pub struct RegistrationParams {
     reg_type: RegType,
     pub(crate) status: Status,
-    act: RatAct,
+    /// RAT from the registration response. None means the response didn't include RAT info.
+    act: Option<RatAct>,
 
     cell_id: Option<String<8>>,
     lac: Option<String<4>>,
@@ -173,6 +175,7 @@ impl From<RegType> for RadioAccessNetwork {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CellularGlobalIdentity {
     /// Registered network operator cell Id.
     cell_id: Option<String<8>>,
@@ -194,6 +197,7 @@ impl CellularGlobalIdentity {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RegistrationState {
     /// CSD (Circuit Switched Data) registration status (registered/searching/roaming etc.).
     pub(crate) csd: CellularRegistrationStatus,
@@ -203,6 +207,9 @@ pub struct RegistrationState {
     pub(crate) eps: CellularRegistrationStatus,
 
     pub(crate) cgi: CellularGlobalIdentity,
+
+    /// Current Radio Access Technology (2G/3G/4G etc.)
+    pub(crate) current_act: Option<RatAct>,
 
     #[cfg(not(feature = "use-upsd-context-activation"))]
     pub(crate) profile_state: ProfileState,
@@ -221,10 +228,16 @@ impl RegistrationState {
             psd: CellularRegistrationStatus::new(),
             eps: CellularRegistrationStatus::new(),
             cgi: CellularGlobalIdentity::new(),
+            current_act: None,
 
             #[cfg(not(feature = "use-upsd-context-activation"))]
             profile_state: ProfileState::Unknown,
         }
+    }
+
+    /// Get the current Radio Access Technology
+    pub fn current_act(&self) -> Option<RatAct> {
+        self.current_act
     }
 
     /// Determine if a given cellular network status value means that we're
@@ -234,13 +247,19 @@ impl RegistrationState {
         self.psd.registered() || self.eps.registered()
     }
 
+    /// Check if registration is denied by any of the network services
+    pub fn is_denied(&self) -> bool {
+        self.eps.get_status() == Status::Denied
+    }
+
     pub fn reset(&mut self) {
         self.csd.reset();
         self.psd.reset();
         self.eps.reset();
     }
 
-    pub fn compare_and_set(&mut self, new_params: RegistrationParams) {
+    /// Compare and set registration state, returning true if RAT changed
+    pub fn compare_and_set(&mut self, new_params: RegistrationParams) -> bool {
         match new_params.reg_type {
             RegType::Creg => {
                 self.csd.set_status(new_params.status);
@@ -253,7 +272,7 @@ impl RegistrationState {
             }
             RegType::Unknown => {
                 error!("unknown reg type");
-                return;
+                return false;
             }
         }
 
@@ -262,13 +281,30 @@ impl RegistrationState {
             self.cgi.cell_id = new_params.cell_id.clone();
             self.cgi.lac = new_params.lac;
         }
+
+        // Track RAT changes - only update if the response actually contains RAT info
+        let rat_changed = if let Some(new_act) = new_params.act {
+            let changed = self.current_act != Some(new_act);
+            if changed {
+                debug!(
+                    "🔄 RAT changed: {:?} -> {:?}",
+                    self.current_act, new_act
+                );
+                self.current_act = Some(new_act);
+            }
+            changed
+        } else {
+            false
+        };
+        rat_changed
     }
 }
 
 impl From<NetworkRegistration> for RegistrationParams {
     fn from(v: NetworkRegistration) -> Self {
         Self {
-            act: RatAct::Gsm,
+            // CREG doesn't provide RAT info, so we don't set it
+            act: None,
             reg_type: RegType::Creg,
             status: v.stat.into(),
             cell_id: None,
@@ -280,11 +316,12 @@ impl From<NetworkRegistration> for RegistrationParams {
 impl From<NetworkRegistrationStatus> for RegistrationParams {
     fn from(v: NetworkRegistrationStatus) -> Self {
         Self {
-            act: RatAct::Gsm,
+            // CREG doesn't typically provide RAT info in a usable format
+            act: None,
             reg_type: RegType::Creg,
             status: v.stat.into(),
-            cell_id: None,
-            lac: None,
+            cell_id: v.ci,
+            lac: v.lac,
         }
     }
 }
@@ -292,7 +329,7 @@ impl From<NetworkRegistrationStatus> for RegistrationParams {
 impl From<GPRSNetworkRegistration> for RegistrationParams {
     fn from(v: GPRSNetworkRegistration) -> Self {
         Self {
-            act: v.act.unwrap_or(RatAct::GsmGprsEdge),
+            act: v.act,
             reg_type: RegType::Cgreg,
             status: v.stat.into(),
             cell_id: v.ci,
@@ -308,7 +345,7 @@ impl From<GPRSNetworkRegistrationStatus> for RegistrationParams {
             status: v.stat.into(),
             cell_id: v.ci,
             lac: v.lac,
-            act: v.act.unwrap_or(RatAct::GsmGprsEdge),
+            act: v.act,
         }
     }
 }
@@ -320,7 +357,7 @@ impl From<EPSNetworkRegistration> for RegistrationParams {
             status: v.stat.into(),
             cell_id: v.ci,
             lac: v.tac,
-            act: v.act.unwrap_or(RatAct::Lte),
+            act: v.act,
         }
     }
 }
@@ -332,7 +369,7 @@ impl From<EPSNetworkRegistrationStatus> for RegistrationParams {
             status: v.stat.into(),
             cell_id: v.ci,
             lac: v.tac,
-            act: v.act.unwrap_or(RatAct::Lte),
+            act: v.act,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add timeout to transport buffer drain on startup
- Don't reboot modem on SIM failure, continue anyway  
- Add lock for AT client sender to prevent message interleaving
- Wait for RAT (Radio Access Technology) change before proceeding
- Add rat_waker and apn_config to shared state
- Improve CMUX max frame size (128 → 256)
- Add debug logging for multiplexer initialization

## Test plan
- [ ] Manual testing on hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)