### PR TITLE
fix: reset response slot before send in ProxyClient

### DIFF
--- a/src/asynch/control.rs
+++ b/src/asynch/control.rs
@@ -76,6 +76,11 @@ impl<'a, const INGRESS_BUF_SIZE: usize> atat::asynch::AtatClient
 
         let sender = self.req_sender.lock().await;
 
+        // Clear any stale response signal left over from prior commands or
+        // late URC-like traffic, so wait_response below returns our command's
+        // response and not a leaked one.
+        self.res_slot.reset();
+
         with_timeout(
             Duration::from_secs(1),
             sender.send(heapless::Vec::try_from(&buf[..len]).unwrap()),


### PR DESCRIPTION
## Summary
- `ProxyClient::send` never cleared the shared `ResponseSlot` before writing a new command, so any leftover signal (a late response from the previous command, a URC that parsed as `Response`, etc.) was consumed by the next `wait_response` call instead of the command's own response.
- Follow the same pattern as `atat::asynch::Client` (which calls `res_slot.reset()` before each write) and reset the slot right after acquiring the sender lock.

## Observed failure
On a LARA-R6 during `prepare_connect`, every command was reading the previous command's response:

```
AT+CIMI sent        → slot contains a stale OK → read as empty → Parse error
AT+CIMI retry sent  → slot contains attempt-1 IMSI → read as "success"
AT+COPS? sent       → slot contains attempt-2 IMSI → parse fails
                    → cell_device.run() errors → "Breaking to reboot modem from network runner"
```

After the fix each command reads its own response and `prepare_connect` proceeds to network registration.

## Test plan
- [ ] Flash on hardware and confirm `prepare_connect` / `AT+COPS?` no longer loops through "Breaking to reboot modem from network runner"
- [ ] Existing atat-based tests still pass