### PR TITLE
fix: only reset desired state to Initialized on PPP drop if DataEstablished

### DIFF
--- a/src/asynch/runner.rs
+++ b/src/asynch/runner.rs
@@ -595,7 +595,9 @@ where
                         // Setting desired state will trigger cell_device runner to run to desired state
                         // If this is not changed when we lose connection it will
                         // skip the wait_for_operation_state dataestablished
-                        self.ch.set_desired_state(OperationState::Initialized);
+                        if self.ch.desired_state(None) == OperationState::DataEstablished {
+                            self.ch.set_desired_state(OperationState::Initialized);
+                        }
                     });
 
                     info!("RUNNING PPP");


### PR DESCRIPTION
## Summary
- In the `OnDrop` guard set up before running the PPP runner, only reset the desired operation state to `Initialized` when the current desired state is still `DataEstablished`.
- Previously, if PPP was dropped while the desired state had already been lowered (e.g. `PowerDown`), the unconditional reset would override that request and prevent the cell-device runner from progressing to the lower state.

## Test plan
- [x] Exercise PPP teardown while a lower desired state is pending (e.g. PowerDown) and confirm the runner continues toward that state.
- [x] Normal PPP drop still transitions back to `Initialized` and reconnects.