### PR TITLE
fix(cellular): flush RX buffer before module identification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ embassy-futures = "0.1"
 embedded-hal = "1.0.0"
 embedded-nal-async = "0.9"
 
-at-cmux = { git = "https://github.com/FactbirdHQ/at-cmux", rev = "d361d68" }
+at-cmux = { git = "https://github.com/FactbirdHQ/at-cmux", rev = "95386b1" }
 
 embassy-net-ppp = { version = "0.3", optional = true }
 embassy-net = { version = "0.9", features = [

--- a/src/asynch/runner.rs
+++ b/src/asynch/runner.rs
@@ -352,6 +352,10 @@ where
             return Err(Error::BaudDetection);
         }
 
+        // Drain any late OK from a timed-out probe AT, so it isn't misread as
+        // the reply to GetModelId (which would desync module identification).
+        self.flush_transport().await;
+
         let mut cmd_buf = [0u8; 128];
         let mut at_client = SimpleClient::new(
             &mut self.transport,

--- a/src/modules/lara_r6.rs
+++ b/src/modules/lara_r6.rs
@@ -15,6 +15,14 @@ impl ModuleParams for LaraR6 {
     fn boot_wait(&self) -> Duration {
         Duration::from_secs(10)
     }
+    // After the power-off pulse the module drops VInt within ~1-2s when it
+    // actually powers off. The default (35s) is the time `power_down` spins
+    // waiting for VInt to fall; on boards where VInt does not reflect power-off
+    // that wait is burned in full on every power-down. 5s is ample to observe a
+    // real power-off while capping that wait.
+    fn power_down_wait(&self) -> Duration {
+        Duration::from_secs(5)
+    }
     fn reboot_command_wait(&self) -> Duration {
         Duration::from_secs(10)
     }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -184,4 +184,15 @@ impl ModuleParams for Module {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Generic;
 
-impl ModuleParams for Generic {}
+impl ModuleParams for Generic {
+    // `Generic` is the fallback used before the module model is identified,
+    // including the per-iteration `power_down()` at the top of `run()` which
+    // fires once at boot before `init()` detects the model. On boards whose
+    // module does not drop VInt during power-off, the default would spin the
+    // full `power_down_wait` on every bring-up; cap it here while still leaving
+    // time to observe a genuine power-off. Detected modules use their own
+    // override.
+    fn power_down_wait(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+}


### PR DESCRIPTION
Stacked on #118.

On cold start the module intermittently falls back to generic parameters: a probe `AT` answered just after its timeout leaves a stale `OK` in the RX buffer, which is misread as the reply to `GetModelId` and desyncs identification. Drain the transport after baud detection to fix it.