### PR TITLE
fix(cellular): fast recovery from a wedged or silent LARA-R6

### DIFF
--- a/src/asynch/control.rs
+++ b/src/asynch/control.rs
@@ -168,6 +168,14 @@ impl<'a, const INGRESS_BUF_SIZE: usize> Control<'a, INGRESS_BUF_SIZE> {
         self.state_ch.set_desired_state(ps);
     }
 
+    /// Make the next power-down skip the graceful AT teardown and hard
+    /// power-cycle via GPIO. Call before driving the state to `PowerDown` when
+    /// the modem is known unresponsive (e.g. the firmware keepalive), so the
+    /// COPS=2/CFUN teardown doesn't burn ~20s of AT timeouts on a dead modem.
+    pub fn request_hard_reset(&self) {
+        self.state_ch.request_hard_reset();
+    }
+
     pub fn set_apn_config(&self, apn: Apn) {
         self.state_ch.set_apn_config(apn);
     }

--- a/src/asynch/network.rs
+++ b/src/asynch/network.rs
@@ -42,6 +42,13 @@ use embassy_futures::select::{select, Either};
 
 use embassy_time::{Duration, Timer};
 
+/// Upper bound on the graceful network-teardown AT commands (COPS=2 deregister
+/// and CFUN radio-off) issued on the `Connected -> Initialized` descent. A
+/// responsive modem completes both in a few seconds; a wedged one would
+/// otherwise block on their 180s AT timeout. When it fires we fall straight
+/// through to the GPIO power-cycle, which is a stronger reset anyway.
+const GRACEFUL_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub struct NetDevice<'a, 'b, C, A> {
     ch: &'b state::Runner<'a>,
     at_client: A,
@@ -662,14 +669,26 @@ where
                     // the next registration attempt to fail (e.g. when
                     // switching SIMs — the modem tries a TAU with the old
                     // SIM's keys instead of a fresh IMSI attach).
-                    let _ = self
-                        .at_client
-                        .send(&SetOperatorSelection {
+                    //
+                    // Bound this graceful teardown with a short timeout. Both
+                    // COPS=2 (deregister) and CFUN=<radio_off> carry a 180s AT
+                    // timeout, so if the modem is mid-blackhole (the ~60-78s
+                    // LARA-R6 baseband silence) each blocks for over a minute,
+                    // stalling the descent to PowerDown. The next step
+                    // (Initialized, Less) hard power-cycles the modem via GPIO
+                    // anyway — a stronger reset than a network deregister — so
+                    // a teardown that can't complete promptly is worthless.
+                    // Skip it and go straight to the power cycle.
+                    let _ = embassy_time::with_timeout(
+                        GRACEFUL_TEARDOWN_TIMEOUT,
+                        self.at_client.send(&SetOperatorSelection {
                             mode: OperatorSelectionMode::Deregister,
                             format: None,
-                        })
+                        }),
+                    )
+                    .await;
+                    let _ = embassy_time::with_timeout(GRACEFUL_TEARDOWN_TIMEOUT, self.radio_off())
                         .await;
-                    self.radio_off().await?;
                     self.ch.set_operation_state(OperationState::Initialized);
                 }
                 (OperationState::DataEstablished, Ordering::Less) => {

--- a/src/asynch/network.rs
+++ b/src/asynch/network.rs
@@ -670,25 +670,30 @@ where
                     // switching SIMs — the modem tries a TAU with the old
                     // SIM's keys instead of a fresh IMSI attach).
                     //
-                    // Bound this graceful teardown with a short timeout. Both
-                    // COPS=2 (deregister) and CFUN=<radio_off> carry a 180s AT
-                    // timeout, so if the modem is mid-blackhole (the ~60-78s
-                    // LARA-R6 baseband silence) each blocks for over a minute,
-                    // stalling the descent to PowerDown. The next step
-                    // (Initialized, Less) hard power-cycles the modem via GPIO
-                    // anyway — a stronger reset than a network deregister — so
-                    // a teardown that can't complete promptly is worthless.
-                    // Skip it and go straight to the power cycle.
-                    let _ = embassy_time::with_timeout(
-                        GRACEFUL_TEARDOWN_TIMEOUT,
-                        self.at_client.send(&SetOperatorSelection {
-                            mode: OperatorSelectionMode::Deregister,
-                            format: None,
-                        }),
-                    )
-                    .await;
-                    let _ = embassy_time::with_timeout(GRACEFUL_TEARDOWN_TIMEOUT, self.radio_off())
+                    // On a hard reset (requested when the modem is known
+                    // unresponsive) skip the teardown entirely: COPS=2 and
+                    // CFUN each carry a 180s AT timeout, so even bounded (see
+                    // GRACEFUL_TEARDOWN_TIMEOUT) they burn ~20s talking to a
+                    // dead modem. The next step (Initialized, Less) GPIO
+                    // power-cycles anyway — a stronger reset than a network
+                    // deregister — so the teardown is pure wasted latency.
+                    if self.ch.take_hard_reset() {
+                        warn!("Hard reset requested — skipping AT teardown, power-cycling");
+                    } else {
+                        // Otherwise still bound the teardown so a modem that
+                        // wedges mid-descent can't block for the full 180s.
+                        let _ = embassy_time::with_timeout(
+                            GRACEFUL_TEARDOWN_TIMEOUT,
+                            self.at_client.send(&SetOperatorSelection {
+                                mode: OperatorSelectionMode::Deregister,
+                                format: None,
+                            }),
+                        )
                         .await;
+                        let _ =
+                            embassy_time::with_timeout(GRACEFUL_TEARDOWN_TIMEOUT, self.radio_off())
+                                .await;
+                    }
                     self.ch.set_operation_state(OperationState::Initialized);
                 }
                 (OperationState::DataEstablished, Ordering::Less) => {

--- a/src/asynch/runner.rs
+++ b/src/asynch/runner.rs
@@ -52,6 +52,7 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use embassy_time::{Duration, Instant, Timer};
+use embedded_io_async::BufRead as _;
 use embedded_io_async::Write as _;
 
 pub(crate) const URC_SUBSCRIBERS: usize = 2;
@@ -62,6 +63,36 @@ pub const CMUX_MAX_FRAME_SIZE: usize = 256;
 pub const CMUX_CHANNEL_SIZE: usize = CMUX_MAX_FRAME_SIZE * 8;
 
 pub const CMUX_CHANNELS: usize = 2;
+
+/// Drain any late/pending bytes still queued on the PPP data channel.
+///
+/// During roaming registration churn the modem can answer the LARA-R6
+/// `AT+USOCR` dial-up workaround up to ~1s late — after `CreateSocket` has
+/// already timed out. If that stray `+USOCR` reply is still in the channel
+/// when we send `ATD*99***1#`, it is mis-parsed as the dial's response
+/// ("ppp dial failed Parse") and the reconnect loop never recovers. Actively
+/// wait for the channel to fall idle before dialing. Takes the channel by ref
+/// (not `&mut self`) so it stays disjoint from the other `select3` futures.
+#[cfg(feature = "lara-r6")]
+async fn drain_data_channel(channel: &mut at_cmux::Channel<'_, CMUX_CHANNEL_SIZE>) {
+    let _ = embassy_time::with_timeout(Duration::from_secs(2), async {
+        loop {
+            let len =
+                match embassy_time::with_timeout(Duration::from_millis(250), channel.fill_buf())
+                    .await
+                {
+                    Ok(Ok(s)) => s.len(),
+                    // 250ms with no new bytes (or a read error): channel is idle.
+                    _ => break,
+                };
+            if len == 0 {
+                break;
+            }
+            channel.consume(len);
+        }
+    })
+    .await;
+}
 
 async fn at_bridge<'a, const INGRESS_BUF_SIZE: usize, const URC_CAPACITY: usize>(
     (rx, tx): (
@@ -544,22 +575,21 @@ where
                     last_start = Some(Instant::now());
 
                     {
-                        // Must be large enough to hold CreateSocket cmd
-                        let mut buf = [0u8; 25];
-
-                        let mut at_client = SimpleClient::new(
-                            &mut self.data_channel,
-                            atat::AtDigester::<Urc>::new(),
-                            &mut buf,
-                            C::AT_CONFIG,
-                        );
-
                         #[cfg(feature = "lara-r6")]
                         //This is needed as a workaround for lara r6 firmware 0.13.
                         // Documentation for workaround: https://content.u-blox.com/sites/default/files/documents/LARA-R6001D-00B-IP_IN_UBX-22008409.pdf
                         // In section B.1.2 Dial-up
                         {
-                            let res = at_client
+                            // Must be large enough to hold CreateSocket cmd
+                            let mut buf = [0u8; 25];
+                            let mut at_client = SimpleClient::new(
+                                &mut self.data_channel,
+                                atat::AtDigester::<Urc>::new(),
+                                &mut buf,
+                                C::AT_CONFIG,
+                            );
+
+                            match at_client
                                 .send(&CreateSocket {
                                     protocol: SocketProtocol::UDP,
                                     local_port: Some(1),
@@ -567,19 +597,48 @@ where
                                     cid: Some(1),
                                     report_aon: None,
                                 })
-                                .await;
-
-                            if let Ok(socket_id) = res {
-                                open_socket_id = Some(socket_id.socket);
-                                info!("Socket opened");
+                                .await
+                            {
+                                Ok(socket_id) => {
+                                    open_socket_id = Some(socket_id.socket);
+                                    info!("Socket opened");
+                                }
+                                // On a slow/roaming modem CreateSocket can time
+                                // out while its +USOCR reply is still in flight;
+                                // the drain below stops that stray reply from
+                                // poisoning the ATD dial.
+                                Err(e) => {
+                                    warn!("CreateSocket failed before PPP dial: {:?}", e)
+                                }
                             }
                         }
 
+                        // Drain any late +USOCR reply (or registration-URC burst)
+                        // still queued on the data channel so it can't be
+                        // mis-parsed as the ATD dial's response — the
+                        // "ppp dial failed Parse" loop that never recovers.
+                        #[cfg(feature = "lara-r6")]
+                        drain_data_channel(&mut self.data_channel).await;
+
                         // Send AT command to enter PPP mode
+                        let mut buf = [0u8; 25];
+                        let mut at_client = SimpleClient::new(
+                            &mut self.data_channel,
+                            atat::AtDigester::<Urc>::new(),
+                            &mut buf,
+                            C::AT_CONFIG,
+                        );
                         let res = at_client.send(&EnterPPP { cid: C::CONTEXT_ID }).await;
 
                         if let Err(e) = res {
                             warn!("ppp dial failed {:?}", e);
+                            // Flush the channel so the retry doesn't inherit a
+                            // stray reply and fail the same way.
+                            #[cfg(feature = "lara-r6")]
+                            {
+                                drop(at_client);
+                                drain_data_channel(&mut self.data_channel).await;
+                            }
                             continue;
                         }
 

--- a/src/asynch/state.rs
+++ b/src/asynch/state.rs
@@ -59,6 +59,7 @@ impl State {
                 apn_config: Apn::None,
                 #[cfg(any(feature = "automatic-apn"))]
                 apn_config: Apn::Automatic,
+                hard_reset: false,
             })),
         }
     }
@@ -75,6 +76,12 @@ pub struct Shared {
     registration_waker: WakerRegistration,
     rat_waker: WakerRegistration,
     apn_config: Apn,
+    /// When set, the next `Connected -> Initialized` descent skips the graceful
+    /// AT teardown (COPS=2 deregister + CFUN radio-off) and goes straight to the
+    /// GPIO power-cycle. Set by the firmware keepalive, which only fires once the
+    /// modem has proven unresponsive — talking AT to a dead modem just burns the
+    /// commands' timeouts (~20s) before the power-cycle that actually recovers it.
+    hard_reset: bool,
 }
 
 #[derive(Clone)]
@@ -202,6 +209,22 @@ impl<'d> Runner<'d> {
                 debug!("State: Operation state unchanged: {:?}", state);
             }
         });
+    }
+
+    /// Request that the next power-down skips the graceful AT teardown and
+    /// hard power-cycles via GPIO. See [`Shared::hard_reset`].
+    pub fn request_hard_reset(&self) {
+        self.shared.lock(|s| {
+            s.borrow_mut().hard_reset = true;
+        });
+    }
+
+    /// Read and clear the hard-reset request.
+    pub(crate) fn take_hard_reset(&self) -> bool {
+        self.shared.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            core::mem::take(&mut s.hard_reset)
+        })
     }
 
     pub fn set_apn_config(&self, apn: Apn) {


### PR DESCRIPTION
Three fixes for a LARA-R6 data-path stall: the modem stops passing data while still registered, so nothing flips `LinkState` and the driver parks until a TCP-level timeout. The stall itself is modem-side (LTE roaming-bearer instability, `+CEER` = `EMM attach failed`, FW 4.22) and isn't fixable here — these make recovery fast instead.

- **Bound the graceful teardown** (10s). `COPS=2` and `CFUN` each carry a 180s AT timeout, so a wedged modem blocked the `Connected -> Initialized` descent for over a minute. Now it falls through to the GPIO power-cycle, a stronger reset anyway.
- **`Control::request_hard_reset()`** — one-shot flag to skip the teardown entirely when the modem is already known unresponsive, where those commands only burn ~20s.
- **Drain the PPP data channel before `ATD`** (lara-r6). During roaming registration churn a late `+USOCR` can arrive after `CreateSocket` has timed out and be mis-parsed as the dial response — a `ppp dial failed Parse` loop that never recovered.

Measured on hardware: recovery ~84s -> ~25s.

Reviewer notes:
- `radio_off()` no longer propagates its error (`?` dropped for `let _ = with_timeout(..)`), so a fast, definite failure is now ignored too, not just a timeout. Intentional — the next step power-cycles regardless — but it is wider than "bound the teardown".
- The hard-reset flag is only consumed on the `Connected -> Initialized` descent. If that descent never happens the flag persists and would skip the teardown on a later, unrelated power-down.
